### PR TITLE
[BE] 멤버 프로필 수정 유효성 검증 및 테스트 코드 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/dto/MemberResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/dto/MemberResponse.java
@@ -1,20 +1,32 @@
 package codesquad.bookkbookk.domain.member.data.dto;
 
 import codesquad.bookkbookk.domain.member.data.entity.Member;
-
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class MemberResponse {
 
     private final Long id;
+    private final String email;
     private final String nickname;
     private final String profileImgUrl;
 
+    @Builder
+    private MemberResponse(Long id, String email, String nickname, String profileImgUrl) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
+
     public static MemberResponse from(Member member) {
-        return new MemberResponse(member.getId(), member.getNickname(), member.getProfileImgUrl());
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImgUrl(member.getProfileImgUrl())
+                .build();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -58,8 +58,11 @@ public class Member {
                 .build();
     }
 
-    public void updateProfile(String nickname, String profileImgUrl) {
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateProfileImgUrl(String profileImgUrl){
         this.profileImgUrl = profileImgUrl;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
@@ -3,14 +3,14 @@ package codesquad.bookkbookk.domain.member.service;
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.image.S3ImageUploader;
 import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileRequest;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
-import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
-
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -30,9 +30,16 @@ public class MemberService {
     public void updateProfile(Long memberId, UpdateProfileRequest updateProfileRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        String imageUrl = s3ImageUploader.upload(updateProfileRequest.getProfileImage()).toString();
+        MultipartFile profileImgFile = updateProfileRequest.getProfileImage();
+        if (!profileImgFile.isEmpty()) {
+            String profileImgUrl = s3ImageUploader.upload(profileImgFile).toString();
+            member.updateProfileImgUrl(profileImgUrl);
+        }
 
-        member.updateProfile(updateProfileRequest.getNickname(), imageUrl);
+        String nickname = updateProfileRequest.getNickname();
+        if (!nickname.isEmpty()) {
+            member.updateNickname(nickname);
+        }
     }
 
 }

--- a/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
@@ -1,11 +1,15 @@
 package codesquad.bookkbookk.member.integration;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 import codesquad.bookkbookk.IntegrationTest;
 import codesquad.bookkbookk.common.error.exception.ApiException;
@@ -15,7 +19,6 @@ import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 import codesquad.bookkbookk.util.TestDataFactory;
-
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -74,6 +77,36 @@ public class MemberTest extends IntegrationTest {
             softAssertions.assertThat(response.statusCode()).isEqualTo(exception.getCode());
             softAssertions.assertThat(response.jsonPath().getObject("", ApiException.class).getMessage())
                     .isEqualTo(exception.getMessage());
+        });
+
+    }
+
+    //프로필 이미지 수정 테스트 미구현
+    @Test
+    @DisplayName("멤버의 프로필을 성공적으로 수정한다.")
+    void updateUserProfile() throws IOException {
+        //given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        //when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .multiPart("profileImage", File.createTempFile("create", "jpeg")
+                            , MediaType.IMAGE_JPEG_VALUE)
+                    .multiPart("nickname", "New nickname")
+                .when()
+                    .patch("/api/members/profile")
+                .then().log().all()
+                    .extract();
+
+        //then
+        Member result = memberRepository.findById(member.getId()).orElseThrow(MemberNotFoundException::new);
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softAssertions.assertThat(result.getNickname()).isEqualTo("New nickname");
         });
 
     }

--- a/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
@@ -46,12 +46,14 @@ public class MemberTest extends IntegrationTest {
                     .get("/api/members")
                 .then().log().all()
                     .extract();
-
+        MemberResponse result = response.jsonPath().getObject("", MemberResponse.class);
         //then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            softAssertions.assertThat(response.jsonPath().getObject("", MemberResponse.class).getId())
-                    .isEqualTo(member.getId());
+            softAssertions.assertThat(result.getId()).isEqualTo(member.getId());
+            softAssertions.assertThat(result.getNickname()).isEqualTo(member.getNickname());
+            softAssertions.assertThat(result.getEmail()).isEqualTo(member.getEmail());
+            softAssertions.assertThat(result.getProfileImgUrl()).isEqualTo(member.getProfileImgUrl());
         });
 
     }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- 멤버 프로필 수정 시 요청 값 유효성 검증
- 멤버 프로필 수정 성공 시 테스트 코드
- 멤버 조회 시 응답에 email 추가
### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요
-  프로필 이미지는 기능 동작이 안되더라구요.. 그래서 테스트를 어떻게 해야할지 아직 잘 모르겠습니다
<!-- 구현한 기능에서 본인의 생각한 과정을 중심으로 써주세요. --->

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
