### PR TITLE
[BE] JwtFilter 리팩토링, accessToken 재발급 기능 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/config/FilterConfig.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/config/FilterConfig.java
@@ -5,6 +5,8 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import codesquad.bookkbookk.common.filter.CorsFilter;
 import codesquad.bookkbookk.common.filter.JwtFilter;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
@@ -22,10 +24,10 @@ public class FilterConfig {
     }
 
     @Bean
-    public FilterRegistrationBean<JwtFilter> jwtFilter(JwtProvider provider) {
+    public FilterRegistrationBean<JwtFilter> jwtFilter(JwtProvider provider, ObjectMapper objectMapper) {
         FilterRegistrationBean<JwtFilter> filterRegistrationBean = new FilterRegistrationBean<>();
 
-        filterRegistrationBean.setFilter(new JwtFilter(provider));
+        filterRegistrationBean.setFilter(new JwtFilter(provider, objectMapper));
         filterRegistrationBean.setOrder(2);
         return filterRegistrationBean;
     }

--- a/be/src/main/java/codesquad/bookkbookk/common/config/WebConfig.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/config/WebConfig.java
@@ -8,16 +8,20 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import codesquad.bookkbookk.common.resolver.JwtArgumentResolver;
+import codesquad.bookkbookk.common.resolver.TokenArgumentResolver;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     private JwtArgumentResolver jwtArgumentResolver;
+    @Autowired
+    private TokenArgumentResolver tokenArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(jwtArgumentResolver);
+        resolvers.add(tokenArgumentResolver);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/RefreshTokenNotSavedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/RefreshTokenNotSavedException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenNotSavedException extends ApiException {
+
+    public RefreshTokenNotSavedException() {
+        super(HttpStatus.NOT_FOUND, "refreshToken에 해당하는 멤버가 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/BearerPrefixNotIncludedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/BearerPrefixNotIncludedException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import codesquad.bookkbookk.common.error.exception.ApiException;
+
+public class BearerPrefixNotIncludedException extends ApiException {
+
+    public BearerPrefixNotIncludedException() {
+        super(HttpStatus.BAD_REQUEST, "Bearer Prefix가 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/MalformedTokenException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/MalformedTokenException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import codesquad.bookkbookk.common.error.exception.ApiException;
+
+public class MalformedTokenException extends ApiException {
+
+    public MalformedTokenException() {
+        super(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/NoAuthorizationHeaderException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/NoAuthorizationHeaderException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import codesquad.bookkbookk.common.error.exception.ApiException;
+
+public class NoAuthorizationHeaderException extends ApiException {
+
+    public NoAuthorizationHeaderException() {
+        super(HttpStatus.UNAUTHORIZED, "Authorization Header가 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/TokenExpiredException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/TokenExpiredException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import codesquad.bookkbookk.common.error.exception.ApiException;
+
+public class TokenExpiredException extends ApiException {
+
+    public TokenExpiredException() {
+        super(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/TokenNotIncludedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/jwt/TokenNotIncludedException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import codesquad.bookkbookk.common.error.exception.ApiException;
+
+public class TokenNotIncludedException extends ApiException {
+
+    public TokenNotIncludedException() {
+        super(HttpStatus.BAD_REQUEST, "토큰이 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
@@ -1,6 +1,7 @@
 package codesquad.bookkbookk.common.filter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -10,17 +11,22 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.util.PatternMatchUtils;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import codesquad.bookkbookk.common.error.ErrorResponse;
+import codesquad.bookkbookk.common.error.exception.ApiException;
+import codesquad.bookkbookk.common.error.exception.jwt.MalformedTokenException;
+import codesquad.bookkbookk.common.error.exception.jwt.NoAuthorizationHeaderException;
+import codesquad.bookkbookk.common.error.exception.jwt.BearerPrefixNotIncludedException;
+import codesquad.bookkbookk.common.error.exception.jwt.TokenExpiredException;
+import codesquad.bookkbookk.common.error.exception.jwt.TokenNotIncludedException;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,8 +35,9 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtFilter implements Filter {
 
     private final String[] getUrlWhiteList = new String[]{};
-    private final String[] postUrlWhiteList = new String[]{"/api/auth/login*", "/api/auth/reissue"};
+    private final String[] postUrlWhiteList = new String[]{"/api/auth/login*"};
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
@@ -42,25 +49,32 @@ public class JwtFilter implements Filter {
             chain.doFilter(request, response);
             return;
         }
-        if (!doesContainToken(httpServletRequest)) {
-            httpServletResponse.sendError(HttpStatus.UNAUTHORIZED.value(), "로그인이 필요합니다.");
+
+        String authorization = httpServletRequest.getHeader("Authorization");
+        if (authorization == null) {
+            writeErrorResponse(new NoAuthorizationHeaderException(), httpServletResponse);
+            return;
+        }
+        if (!authorization.startsWith("Bearer ")) {
+            writeErrorResponse(new BearerPrefixNotIncludedException(), httpServletResponse);
             return;
         }
 
+        String token = authorization.substring("Bearer ".length());
         try {
-            String accessToken = jwtProvider.getToken(httpServletRequest);
-            jwtProvider.extractMemberId(accessToken);
-            chain.doFilter(request, response);
-        } catch (JsonParseException e) {
-            log.error("JsonParseException");
-            httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());
-        } catch (MalformedJwtException | UnsupportedJwtException e) {
-            log.error("JwtException");
-            httpServletResponse.sendError(HttpStatus.UNAUTHORIZED.value(), "인증 오류");
+            jwtProvider.validateToken(token);
+        } catch (IllegalArgumentException e) {
+            writeErrorResponse(new TokenNotIncludedException(), httpServletResponse);
+            return;
+        } catch (MalformedJwtException | SecurityException e) {
+            writeErrorResponse(new MalformedTokenException(), httpServletResponse);
+            return;
         } catch (ExpiredJwtException e) {
-            log.error("JwtTokenExpired");
-            httpServletResponse.sendError(HttpStatus.FORBIDDEN.value(), "토큰이 만료 되었습니다");
+            writeErrorResponse(new TokenExpiredException(), httpServletResponse);
+            return;
         }
+
+        chain.doFilter(request, response);
     }
 
     private boolean checkGetWhiteList(HttpServletRequest httpServletRequest) {
@@ -73,9 +87,16 @@ public class JwtFilter implements Filter {
         return httpServletRequest.getMethod().equals("POST") && PatternMatchUtils.simpleMatch(postUrlWhiteList, url);
     }
 
-    private boolean doesContainToken(HttpServletRequest request) {
-        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-        return authorization != null && authorization.startsWith("Bearer ");
+    private void writeErrorResponse(ApiException apiException, HttpServletResponse httpServletResponse)
+            throws IOException {
+        httpServletResponse.setCharacterEncoding("UTF-8");
+        ErrorResponse errorResponse = ErrorResponse.from(apiException);
+        PrintWriter writer = httpServletResponse.getWriter();
+
+        log.error(apiException.getClass().getSimpleName() + ": " + apiException.getMessage());
+        httpServletResponse.setStatus(errorResponse.getCode());
+        String jsonBody = objectMapper.writeValueAsString(errorResponse);
+        writer.print(jsonBody);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtFilter implements Filter {
 
     private final String[] getUrlWhiteList = new String[]{};
-    private final String[] postUrlWhiteList = new String[]{"/api/auth/login*"};
+    private final String[] postUrlWhiteList = new String[]{"/api/auth/login*", "/api/auth/reissue"};
     private final JwtProvider jwtProvider;
 
     @Override

--- a/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
@@ -64,6 +64,13 @@ public class JwtProvider {
                 .get("memberId", Long.class);
     }
 
+    public void validateToken(String token) {
+        Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parse(token);
+    }
+
     private String createToken(Map<String, Object> claims, Date expiration) {
         return Jwts.builder()
                 .expiration(expiration)

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/Token.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/Token.java
@@ -1,0 +1,12 @@
+package codesquad.bookkbookk.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Token {
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/TokenArgumentResolver.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/TokenArgumentResolver.java
@@ -1,0 +1,36 @@
+package codesquad.bookkbookk.common.resolver;
+
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import codesquad.bookkbookk.common.jwt.JwtProvider;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class TokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberId.class) && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public String resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return jwtProvider.getToken(Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)));
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/TokenArgumentResolver.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/TokenArgumentResolver.java
@@ -24,7 +24,7 @@ public class TokenArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(MemberId.class) && parameter.getParameterType().equals(Long.class);
+        return parameter.hasParameterAnnotation(Token.class) && parameter.getParameterType().equals(String.class);
     }
 
     @Override

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.bookkbookk.common.resolver.Token;
 import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
+import codesquad.bookkbookk.domain.auth.data.dto.ReissueResponse;
 import codesquad.bookkbookk.domain.auth.service.OAuthService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,14 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .body(loginResponse);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ReissueResponse> reissueAccessToken(@Token String refreshToken) {
+        ReissueResponse response = oAuthService.reissueAccessToken(refreshToken);
+
+        return ResponseEntity.ok()
+                .body(response);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/ReissueResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/ReissueResponse.java
@@ -1,0 +1,12 @@
+package codesquad.bookkbookk.domain.auth.data.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReissueResponse {
+
+    private final String accessToken;
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
@@ -23,14 +23,13 @@ public class MemberRefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_refresh_token_id")
     private Long id;
-    @OneToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
     @Column(name = "refresh_token")
     private String refreshToken;
 
-    public MemberRefreshToken(Member member, String refreshToken) {
-        this.member = member;
+    public MemberRefreshToken(Long memberId, String refreshToken) {
+        this.memberId = memberId;
         this.refreshToken = refreshToken;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
@@ -14,19 +14,24 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "refresh_token")
+@Entity(name = "member_refresh_token")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class RefreshToken {
+public class MemberRefreshToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "refresh_token_id")
+    @Column(name = "member_refresh_token_id")
     private Long id;
     @OneToOne
     @JoinColumn(name = "member_id")
     private Member member;
     @Column(name = "refresh_token")
     private String refreshToken;
+
+    public MemberRefreshToken(Member member, String refreshToken) {
+        this.member = member;
+        this.refreshToken = refreshToken;
+    }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/RefreshToken.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/RefreshToken.java
@@ -1,0 +1,32 @@
+package codesquad.bookkbookk.domain.auth.data.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
@@ -9,6 +9,6 @@ import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshToken, Long> {
 
-    Optional<Member> findMemberByRefreshToken(String refreshToken);
+    Optional<MemberRefreshToken> findByRefreshToken(String refreshToken);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
@@ -1,9 +1,14 @@
 package codesquad.bookkbookk.domain.auth.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshToken, Long> {
+
+    Optional<Member> findMemberByRefreshToken(String refreshToken);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
-import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshToken, Long> {
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/MemberRefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package codesquad.bookkbookk.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
+
+public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshToken, Long> {
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
@@ -13,6 +13,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
+import codesquad.bookkbookk.common.error.exception.RefreshTokenNotSavedException;
 import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginRequest;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
@@ -55,8 +56,8 @@ public class OAuthService {
 
     @Transactional(readOnly = true)
     public ReissueResponse reissueAccessToken(String refreshToken) {
-        Member member = memberRefreshTokenRepository.findMemberByRefreshToken(refreshToken)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRefreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(RefreshTokenNotSavedException::new).getMember();
         String accessToken = jwtProvider.createAccessToken(member.getId());
 
         return new ReissueResponse(accessToken);

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
@@ -12,10 +12,12 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginRequest;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
 import codesquad.bookkbookk.domain.auth.data.dto.OAuthTokenResponse;
+import codesquad.bookkbookk.domain.auth.data.dto.ReissueResponse;
 import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
 import codesquad.bookkbookk.domain.auth.data.provider.OAuthProvider;
 import codesquad.bookkbookk.common.jwt.Jwt;
@@ -49,6 +51,15 @@ public class OAuthService {
         memberRefreshTokenRepository.save(memberRefreshToken);
 
         return LoginResponse.of(jwt, doesMemberExist);
+    }
+
+    @Transactional(readOnly = true)
+    public ReissueResponse reissueAccessToken(String refreshToken) {
+        Member member = memberRefreshTokenRepository.findMemberByRefreshToken(refreshToken)
+                .orElseThrow(MemberNotFoundException::new);
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        return new ReissueResponse(accessToken);
     }
 
     private Member getLoginMember(LoginRequest loginRequest, boolean doesMemberExist) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
@@ -48,7 +48,7 @@ public class OAuthService {
         boolean doesMemberExist = memberRepository.existsByEmail(loginRequest.getEmail());
         Member loginMember = getLoginMember(loginRequest, doesMemberExist);
         Jwt jwt = jwtProvider.createJwt(loginMember.getId());
-        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(loginMember, jwt.getRefreshToken());
+        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(loginMember.getId(), jwt.getRefreshToken());
         memberRefreshTokenRepository.save(memberRefreshToken);
 
         return LoginResponse.of(jwt, doesMemberExist);
@@ -56,9 +56,9 @@ public class OAuthService {
 
     @Transactional(readOnly = true)
     public ReissueResponse reissueAccessToken(String refreshToken) {
-        Member member = memberRefreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(RefreshTokenNotSavedException::new).getMember();
-        String accessToken = jwtProvider.createAccessToken(member.getId());
+        Long memberId = memberRefreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(RefreshTokenNotSavedException::new).getMemberId();
+        String accessToken = jwtProvider.createAccessToken(memberId);
 
         return new ReissueResponse(accessToken);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/OAuthService.java
@@ -16,9 +16,11 @@ import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginRequest;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
 import codesquad.bookkbookk.domain.auth.data.dto.OAuthTokenResponse;
+import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
 import codesquad.bookkbookk.domain.auth.data.provider.OAuthProvider;
 import codesquad.bookkbookk.common.jwt.Jwt;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
+import codesquad.bookkbookk.domain.auth.repository.MemberRefreshTokenRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class OAuthService {
 
     private final MemberRepository memberRepository;
+    private final MemberRefreshTokenRepository memberRefreshTokenRepository;
     private final OAuthProvider oAuthProvider;
     private final JwtProvider jwtProvider;
 
@@ -42,6 +45,8 @@ public class OAuthService {
         boolean doesMemberExist = memberRepository.existsByEmail(loginRequest.getEmail());
         Member loginMember = getLoginMember(loginRequest, doesMemberExist);
         Jwt jwt = jwtProvider.createJwt(loginMember.getId());
+        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(loginMember, jwt.getRefreshToken());
+        memberRefreshTokenRepository.save(memberRefreshToken);
 
         return LoginResponse.of(jwt, doesMemberExist);
     }

--- a/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
@@ -1,0 +1,67 @@
+package codesquad.bookkbookk.auth.integration;
+
+import java.io.File;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import codesquad.bookkbookk.IntegrationTest;
+import codesquad.bookkbookk.common.error.exception.ApiException;
+import codesquad.bookkbookk.common.jwt.JwtProvider;
+import codesquad.bookkbookk.domain.auth.data.dto.ReissueResponse;
+import codesquad.bookkbookk.domain.auth.data.entity.MemberRefreshToken;
+import codesquad.bookkbookk.domain.auth.repository.MemberRefreshTokenRepository;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.domain.member.service.MemberService;
+import codesquad.bookkbookk.util.TestDataFactory;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class AuthTest extends IntegrationTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberRefreshTokenRepository memberRefreshTokenRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("refreshToken으로 accessToken 재발급을 한다.")
+    void reissueAccessToken() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+        String refreshToken = jwtProvider.createRefreshToken();
+        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(member, refreshToken);
+        memberRefreshTokenRepository.save(memberRefreshToken);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + refreshToken)
+                .when()
+                    .post("/api/auth/reissue")
+                .then().log().all()
+                    .extract();
+
+        // then
+        SoftAssertions.assertSoftly(assertions -> {
+            assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertions.assertThat(response.jsonPath().getString("accessToken"))
+                    .isNotBlank();
+            assertions.assertThat(response.jsonPath().getString("accessToken"))
+                    .isNotEqualTo(accessToken);
+        });
+    }
+
+}

--- a/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
@@ -42,7 +42,7 @@ public class AuthTest extends IntegrationTest {
         memberRepository.save(member);
         String accessToken = jwtProvider.createAccessToken(member.getId());
         String refreshToken = jwtProvider.createRefreshToken();
-        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(member, refreshToken);
+        MemberRefreshToken memberRefreshToken = new MemberRefreshToken(member.getId(), refreshToken);
         memberRefreshTokenRepository.save(memberRefreshToken);
 
         // when

--- a/be/src/test/java/codesquad/bookkbookk/filter/FilterTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/filter/FilterTest.java
@@ -2,13 +2,25 @@ package codesquad.bookkbookk.filter;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Date;
+
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.error.ErrorResponse;
+import codesquad.bookkbookk.common.error.exception.jwt.MalformedTokenException;
+import codesquad.bookkbookk.common.error.exception.jwt.NoAuthorizationHeaderException;
+import codesquad.bookkbookk.common.jwt.JwtProvider;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -19,6 +31,9 @@ class FilterTest {
     @LocalServerPort
     private int port;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     @BeforeEach
     public void setup() {
         RestAssured.port = port;
@@ -28,6 +43,8 @@ class FilterTest {
     @DisplayName("토큰이 필요한 요청에 토큰을 넣지 않으면 필터가 작동한다.")
     void requestWithOutToken() throws Exception {
         // given
+        NoAuthorizationHeaderException exception = new NoAuthorizationHeaderException();
+
         // when
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
@@ -37,7 +54,39 @@ class FilterTest {
                     .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        SoftAssertions.assertSoftly(assertions -> {
+            assertThat(response.statusCode()).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
+                    .isEqualTo(exception.getMessage());
+        });
+
+    }
+
+    @Test
+    @DisplayName("변형된 토큰이 요청에 포함되면 필터가 작동한다.")
+    void requestWithMalformedToken() throws Exception {
+        // given
+        MalformedTokenException exception = new MalformedTokenException();
+        String token = Jwts.builder()
+                .expiration(new Date(System.currentTimeMillis() + 30000))
+                .signWith(Keys.hmacShaKeyFor("thisiskeyfortestbookkbookk1234512356!!".getBytes()))
+                .compact();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .when()
+                    .get("api/members")
+                .then().log().all()
+                    .extract();
+
+        // then
+        SoftAssertions.assertSoftly(assertions -> {
+            assertThat(response.statusCode()).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
+                    .isEqualTo(exception.getMessage());
+        });
     }
 
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- JwtFilter와 JwtProvider를 리팩토링 했습니다.
- accessToken을 재발급 하는 기능을 구현했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- JwtFilter
  - JwtFilter의 경우 예외를 처리할 때 ExceptionHandler에서 처리를 할 수 없어 HttpServletResponse.sendError() 메서드를 통해 에러 메세지를 보내주고 있었습니다. 하지만 이 경우 에러 메세지를 저희가 원하는 방식으로 보낼 수 없습니다. 그래서 직접 PrintWriter를 호출하고 에러메세지를 넣어 주었습니다.
  - JWT 라이브러리에서 던지는 예외를 그대로 사용하지 않고 한번 커스터마이징을 해서 원하는 메세지를 전송하게 했습니다.
  - JWT 라이브러리가 최신 버전이여서 던지는 예외의 종류가 달라졌습니다. 이에 예외를 변경했습니다.
- AccessToken 재발급
  - 멤버가 로그인할 때 만들어지는 refreshToken을 member_refresh_token 테이블에 저장합니다.
  - 재발급 path로 요청을 보내면 refreshToken을 받고 member_refresh_token에서 refreshToken으로 member를 찾고 찾은 member의 id로 accessToken을 만들고 반환합니다.

### 리뷰어에게 한마디 부탁드려요.
JwtFilter를 중점으로 보면 좋을 것 같습니다. 너무 오래걸렸네요. 코드 자체에 만족은 하는데 효율은 별로입니다.
