### PR TITLE
[BE] MutlipartFile null 체크 버그 수정, 멤버 프로필 수정 응답 변경

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -35,7 +35,7 @@ public class BookClubService {
         String profileImgUrl = DEFAULT_BOOK_CLUB_IMAGE_URL;
 
         MultipartFile profileImgFile = request.getProfileImage();
-        if (!profileImgFile.isEmpty()) {
+        if (profileImgFile != null) {
             profileImgUrl = s3ImageUploader.upload(profileImgFile).toString();
         }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/controller/MemberController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileRequest;
+import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileResponse;
 import codesquad.bookkbookk.domain.member.service.MemberService;
 import codesquad.bookkbookk.common.resolver.MemberId;
 
@@ -30,11 +31,12 @@ public class MemberController {
     }
 
     @PatchMapping("/profile")
-    public ResponseEntity<String> updateProfile(@MemberId Long memberId,
-                                                @ModelAttribute UpdateProfileRequest updateProfileRequest) {
-        memberService.updateProfile(memberId, updateProfileRequest);
+    public ResponseEntity<UpdateProfileResponse> updateProfile(@MemberId Long memberId,
+                                                               @ModelAttribute UpdateProfileRequest request) {
+        UpdateProfileResponse response = memberService.updateProfile(memberId, request);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                .body(response);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/dto/UpdateProfileResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/dto/UpdateProfileResponse.java
@@ -1,0 +1,16 @@
+package codesquad.bookkbookk.domain.member.data.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateProfileResponse {
+
+    private final String newNickname;
+    private final String newProfileImgUrl;
+
+    public UpdateProfileResponse(String newNickname, String newProfileImgUrl) {
+        this.newNickname = newNickname;
+        this.newProfileImgUrl = newProfileImgUrl;
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
@@ -11,6 +11,7 @@ import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileRequest;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -31,7 +32,7 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
         MultipartFile profileImgFile = updateProfileRequest.getProfileImage();
-        if (!profileImgFile.isEmpty()) {
+        if (profileImgFile != null) {
             String profileImgUrl = s3ImageUploader.upload(profileImgFile).toString();
             member.updateProfileImgUrl(profileImgUrl);
         }

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.image.S3ImageUploader;
 import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileRequest;
+import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileResponse;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 
@@ -28,7 +29,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateProfile(Long memberId, UpdateProfileRequest updateProfileRequest) {
+    public UpdateProfileResponse updateProfile(Long memberId, UpdateProfileRequest updateProfileRequest) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
         MultipartFile profileImgFile = updateProfileRequest.getProfileImage();
@@ -41,6 +42,8 @@ public class MemberService {
         if (!nickname.isEmpty()) {
             member.updateNickname(nickname);
         }
+
+        return new UpdateProfileResponse(member.getNickname(), member.getProfileImgUrl());
     }
 
 }


### PR DESCRIPTION
isEmpty가 null체크를 하지 못해서 != null로 체크

### 구현한 기능이 어떤 건가요?
- MultipartFile null 검증 시 isEmpty가 null체크를 하지 못해서 != null 방식으로 체크
- 멤버 프로필 수정 시, 수정된 닉네임, 수정된 이미지 url을 응답하도록 변경
<!-- 구현 기능을 대략적으로 설명해 주세요. --->

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

<!-- 구현한 기능에서 본인의 생각한 과정을 중심으로 써주세요. --->

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
