### PR TITLE
[BE]: 멤버 책 조회 기능 리팩토링 & 북클럽 책 조회 기능 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/book/controller/BookController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/controller/BookController.java
@@ -1,18 +1,14 @@
 package codesquad.bookkbookk.domain.book.controller;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.common.resolver.MemberId;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookRequest;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookResponse;
-import codesquad.bookkbookk.domain.book.data.dto.ReadBookResponse;
 import codesquad.bookkbookk.domain.book.service.BookService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,14 +23,6 @@ public class BookController {
     @PostMapping
     public ResponseEntity<CreateBookResponse> createBook(@MemberId Long memberId, @RequestBody CreateBookRequest request) {
         CreateBookResponse response = bookService.createBook(memberId, request);
-
-        return ResponseEntity.ok()
-                .body(response);
-    }
-
-    @GetMapping
-    public ResponseEntity<ReadBookResponse> readBooks(@MemberId Long memberId, Pageable pageable) {
-        ReadBookResponse response = bookService.readBooks(memberId, pageable);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/dto/ReadBookClubBookResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/dto/ReadBookClubBookResponse.java
@@ -1,0 +1,61 @@
+package codesquad.bookkbookk.domain.book.data.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Slice;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadBookClubBookResponse {
+
+    private final Boolean hasNext;
+    private final List<BookResponse> books;
+
+    public static ReadBookClubBookResponse from(Slice<Book> books) {
+        return new ReadBookClubBookResponse(books.hasNext(), BookResponse.from(books));
+    }
+
+    @Getter
+    public static class BookResponse {
+
+        private final Long id;
+        private final String title;
+        private final String cover;
+        private final String author;
+        private final String category;
+
+        @Builder
+        private BookResponse(Long id, String title, String cover, String author, String category) {
+            this.id = id;
+            this.title = title;
+            this.cover = cover;
+            this.author = author;
+            this.category = category;
+        }
+
+        public static List<BookResponse> from(Slice<Book> books) {
+            return books.getContent().stream()
+                    .map(BookResponse::from)
+                    .collect(Collectors.toUnmodifiableList());
+        }
+
+        private static BookResponse from(Book book) {
+            return BookResponse.builder()
+                    .id(book.getId())
+                    .title(book.getTitle())
+                    .cover(book.getCover())
+                    .author(book.getAuthor())
+                    .category(book.getCategory())
+                    .build();
+        }
+
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.domain.book.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,5 +15,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
             "ON book.id = member_book.book.id " +
             "WHERE member_book.member.id = :memberId")
     Page<Book> findBooksByMemberId(Long memberId, Pageable pageable);
+    Slice<Book> findBooksByBookClubId(Long bookClubId, Pageable pageable);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.domain.book.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import codesquad.bookkbookk.common.error.exception.BookClubNotFoundException;
@@ -9,6 +10,7 @@ import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookRequest;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookResponse;
+import codesquad.bookkbookk.domain.book.data.dto.ReadBookClubBookResponse;
 import codesquad.bookkbookk.domain.book.data.dto.ReadBookResponse;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.data.entity.MemberBook;
@@ -53,6 +55,12 @@ public class BookService {
         Page<Book> books = bookRepository.findBooksByMemberId(memberId, pageable);
 
         return ReadBookResponse.from(books);
+    }
+
+    public ReadBookClubBookResponse readBookClubBooks(Long bookClubId, Pageable pageable) {
+        Slice<Book> books = bookRepository.findBooksByBookClubId(bookClubId, pageable);
+
+        return ReadBookClubBookResponse.from(books);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
@@ -2,6 +2,8 @@ package codesquad.bookkbookk.domain.bookclub.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -9,9 +11,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.common.resolver.MemberId;
+import codesquad.bookkbookk.domain.book.data.dto.ReadBookClubBookResponse;
+import codesquad.bookkbookk.domain.book.service.BookService;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateBookClubRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateInvitationUrlRequest;
@@ -31,6 +36,7 @@ public class BookClubController {
 
     private final BookClubService bookClubService;
     private final BookClubInvitationService bookClubInvitationService;
+    private final BookService bookService;
 
     @PostMapping
     public ResponseEntity<CreateBookClubResponse> createBookClub(@MemberId Long memberId,
@@ -70,6 +76,16 @@ public class BookClubController {
     public ResponseEntity<JoinBookClubResponse> joinBookclub(@MemberId Long memberId,
                                                              @RequestBody JoinBookClubRequest joinBookClubRequest) {
         JoinBookClubResponse response = bookClubInvitationService.joinBookClub(memberId, joinBookClubRequest);
+
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @GetMapping("/{bookClubId}/books")
+    public ResponseEntity<ReadBookClubBookResponse> readBookClubBooks(@PathVariable Long bookClubId, @RequestParam Integer cursor,
+                                                         @RequestParam Integer size) {
+        Pageable pageable = PageRequest.of(cursor, size);
+        ReadBookClubBookResponse response = bookService.readBookClubBooks(bookClubId, pageable);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/controller/MemberController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package codesquad.bookkbookk.domain.member.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -7,6 +8,8 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.bookkbookk.domain.book.data.dto.ReadBookResponse;
+import codesquad.bookkbookk.domain.book.service.BookService;
 import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileRequest;
 import codesquad.bookkbookk.domain.member.data.dto.UpdateProfileResponse;
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
     private final MemberService memberService;
+    private final BookService bookService;
 
     @GetMapping
     public ResponseEntity<MemberResponse> readMember(@MemberId Long memberId) {
@@ -34,6 +38,14 @@ public class MemberController {
     public ResponseEntity<UpdateProfileResponse> updateProfile(@MemberId Long memberId,
                                                                @ModelAttribute UpdateProfileRequest request) {
         UpdateProfileResponse response = memberService.updateProfile(memberId, request);
+
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @GetMapping("/books")
+    public ResponseEntity<ReadBookResponse> readBooks(@MemberId Long memberId, Pageable pageable) {
+        ReadBookResponse response = bookService.readBooks(memberId, pageable);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/test/java/codesquad/bookkbookk/book/integration/BookTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/book/integration/BookTest.java
@@ -1,7 +1,5 @@
 package codesquad.bookkbookk.book.integration;
 
-import java.util.LinkedHashMap;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +15,6 @@ import codesquad.bookkbookk.common.jwt.JwtProvider;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookRequest;
 import codesquad.bookkbookk.domain.book.data.dto.CreateBookResponse;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
-import codesquad.bookkbookk.domain.book.data.entity.MemberBook;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.book.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
@@ -141,48 +138,6 @@ public class BookTest extends IntegrationTest {
             softAssertions.assertThat(response.statusCode()).isEqualTo(exception.getCode());
             softAssertions.assertThat(response.jsonPath().getObject("", ApiException.class).getMessage())
                     .isEqualTo(exception.getMessage());
-        });
-    }
-
-    @Test
-    @DisplayName("요청한 멤버가 참여한 책들을 페이지로 나눠서 보내준다.")
-    void readBooks() {
-        // given
-        Member member = TestDataFactory.createMember();
-        memberRepository.save(member);
-
-        BookClub bookClub = TestDataFactory.createBookClub();
-        bookClubRepository.save(bookClub);
-
-        Book book1 = TestDataFactory.createBook1(bookClub);
-        bookRepository.save(book1);
-        Book book2 = TestDataFactory.createBook2(bookClub);
-        bookRepository.save(book2);
-
-        MemberBook memberBook1 = new MemberBook(member, book1);
-        memberBookRepository.save(memberBook1);
-
-        MemberBook memberBook2 = new MemberBook(member, book2);
-        memberBookRepository.save(memberBook2);
-
-        String accessToken = jwtProvider.createAccessToken(member.getId());
-
-        // when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .queryParam("page", 0)
-                .queryParam("size", 1)
-                .when()
-                .get("/api/books")
-                .then().log().all()
-                .extract();
-
-        // then
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            softAssertions.assertThat(((LinkedHashMap) response.jsonPath().getList("books").get(0)).get("title"))
-                    .isEqualTo("신데렐라");
         });
     }
 

--- a/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
@@ -168,5 +168,4 @@ public class MemberTest extends IntegrationTest {
         });
     }
 
-
 }

--- a/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.member.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +16,12 @@ import codesquad.bookkbookk.IntegrationTest;
 import codesquad.bookkbookk.common.error.exception.ApiException;
 import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.book.data.entity.MemberBook;
+import codesquad.bookkbookk.domain.book.repository.BookRepository;
+import codesquad.bookkbookk.domain.book.repository.MemberBookRepository;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.member.data.dto.MemberResponse;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
@@ -27,6 +34,12 @@ public class MemberTest extends IntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private BookClubRepository bookClubRepository;
+    @Autowired
+    private BookRepository bookRepository;
+    @Autowired
+    private MemberBookRepository memberBookRepository;
     @Autowired
     private JwtProvider jwtProvider;
 
@@ -112,5 +125,48 @@ public class MemberTest extends IntegrationTest {
         });
 
     }
+
+    @Test
+    @DisplayName("요청한 멤버가 참여한 책들을 페이지로 나눠서 보내준다.")
+    void readBooks() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub();
+        bookClubRepository.save(bookClub);
+
+        Book book1 = TestDataFactory.createBook1(bookClub);
+        bookRepository.save(book1);
+        Book book2 = TestDataFactory.createBook2(bookClub);
+        bookRepository.save(book2);
+
+        MemberBook memberBook1 = new MemberBook(member, book1);
+        memberBookRepository.save(memberBook1);
+
+        MemberBook memberBook2 = new MemberBook(member, book2);
+        memberBookRepository.save(memberBook2);
+
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .queryParam("page", 0)
+                .queryParam("size", 1)
+                .when()
+                .get("/api/members/books")
+                .then().log().all()
+                .extract();
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softAssertions.assertThat(((LinkedHashMap) response.jsonPath().getList("books").get(0)).get("title"))
+                    .isEqualTo("신데렐라");
+        });
+    }
+
 
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- 북클럽 아이디로 책을 조회해야하기에 멤버 책 조회 기능을 Book 도메인 에서 Member 도메인으로 이식합니다.
- BookClub도메인에서 책 조회 기능을 구현합니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 기존에는 bookController에서 책 조회를 관리했었습니다. 멤버의 책만 조회하기에 그렇게 하나의 Api로 조회 기능을 구현했습니다. 그런데 로직상 모임을 만들 때 북클럽의 책들도 조회하는 기능이 필요해졌습니다. 그래서 멤버의 책 조회를 MemberController에, 북클럽의 책 조회를 BookClubController에 구현했습니다.
- 쿼리 스트링으로 type을 받아서 member의 책을 조회하는 경우와 bookClub의 책을 경우를 나눌 수 있지만, 반환하는 객체의 종류가 다릅니다.(Member의 조회는 페이지, bookClubd의 조회는 슬라이스). 나중에 고민을 더 해야할 것 같은데,  일단은 빠른 구현을 위해 api를 분리했습니다.

