### PR TITLE
[BE] 북클럽 상세 조회 기능 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -13,7 +13,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import codesquad.bookkbookk.common.error.exception.MalformedIsbnException;
-import codesquad.bookkbookk.domain.book.data.type.Status;
+import codesquad.bookkbookk.domain.book.data.type.BookStatus;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 
 import lombok.AccessLevel;
@@ -47,8 +47,8 @@ public class Book {
     @Column(nullable = false)
     private String category;
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
-    private Status status;
+    @Column(name = "book_status", nullable = false)
+    private BookStatus bookStatus;
 
 
     @Builder
@@ -59,7 +59,7 @@ public class Book {
         this.cover = cover;
         this.author = author;
         this.category = category;
-        this.status = Status.PENDING;
+        this.bookStatus = BookStatus.PENDING;
     }
 
     private String validateAndFormatISBN(String isbn) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/type/BookStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/type/BookStatus.java
@@ -1,6 +1,6 @@
 package codesquad.bookkbookk.domain.book.data.type;
 
-public enum Status {
+public enum BookStatus {
 
     PENDING, IN_PROGRESS, COMPLETED;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
@@ -23,6 +23,7 @@ import codesquad.bookkbookk.domain.bookclub.data.dto.CreateInvitationUrlRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.InvitationUrlResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubResponse;
+import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.service.BookClubService;
 
@@ -85,6 +86,14 @@ public class BookClubController {
                                                          @RequestParam Integer size) {
         Pageable pageable = PageRequest.of(cursor, size);
         ReadBookClubBookResponse response = bookService.readBookClubBooks(bookClubId, pageable);
+
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @GetMapping("/{bookClubId}")
+    public ResponseEntity<ReadBookClubDetailResponse> readBookClubDetail(@PathVariable Long bookClubId) {
+        ReadBookClubDetailResponse response = bookClubService.readBookClubDetail(bookClubId);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
@@ -1,0 +1,44 @@
+package codesquad.bookkbookk.domain.bookclub.data.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse{
+
+    private final LocalDateTime closedTime;
+
+    @Builder
+    private ClosedBookClubDetailResponse(String name, BookClubStatus status, String profileImgUrl,
+                                         LocalDateTime createdTime, ReadBookClubLastBook readBookClubLastBook,
+                                         List<ReadBookClubMember> readBookClubMembers,
+                                         LocalDateTime closedTime) {
+        super(name, status, profileImgUrl, createdTime, readBookClubLastBook, readBookClubMembers);
+        this.closedTime = closedTime;
+    }
+
+    public static ClosedBookClubDetailResponse from(BookClub bookClub) {
+        Book lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
+        List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
+
+        return ClosedBookClubDetailResponse.builder()
+                .name(bookClub.getName())
+                .status(bookClub.getBookClubStatus())
+                .profileImgUrl(bookClub.getProfileImgUrl())
+                .createdTime(bookClub.getCreatedTime())
+                .readBookClubLastBook(ReadBookClubLastBook.from(lastBook))
+                .readBookClubMembers(ReadBookClubMember.from(members))
+                .closedTime(bookClub.getClosedTime())
+                .build();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
@@ -1,0 +1,44 @@
+package codesquad.bookkbookk.domain.bookclub.data.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OpenBookClubDetailResponse extends ReadBookClubDetailResponse{
+
+    private final LocalDateTime upcomingGatheringDate;
+
+    @Builder
+    private OpenBookClubDetailResponse(String name, BookClubStatus status, String profileImgUrl,
+                                         LocalDateTime createdTime, ReadBookClubDetailResponse.ReadBookClubLastBook readBookClubLastBook,
+                                         List<ReadBookClubDetailResponse.ReadBookClubMember> readBookClubMembers,
+                                         LocalDateTime upcomingGatheringDate) {
+        super(name, status, profileImgUrl, createdTime, readBookClubLastBook, readBookClubMembers);
+        this.upcomingGatheringDate = upcomingGatheringDate;
+    }
+
+    public static OpenBookClubDetailResponse from(BookClub bookClub) {
+        Book lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
+        List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
+
+        return OpenBookClubDetailResponse.builder()
+                .name(bookClub.getName())
+                .status(bookClub.getBookClubStatus())
+                .profileImgUrl(bookClub.getProfileImgUrl())
+                .createdTime(bookClub.getCreatedTime())
+                .readBookClubLastBook(ReadBookClubLastBook.from(lastBook))
+                .readBookClubMembers(ReadBookClubMember.from(members))
+                .upcomingGatheringDate(bookClub.getUpcomingGatheringDate())
+                .build();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
@@ -1,0 +1,85 @@
+package codesquad.bookkbookk.domain.bookclub.data.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReadBookClubDetailResponse {
+
+    private final String name;
+    private final BookClubStatus status;
+    private final String profileImgUrl;
+    private final LocalDateTime createdTime;
+    private final ReadBookClubLastBook lastBook;
+    private final List<ReadBookClubMember> members;
+
+    public ReadBookClubDetailResponse(String name, BookClubStatus status, String profileImgUrl,
+                                      LocalDateTime createdTime, ReadBookClubLastBook readBookClubLastBook,
+                                      List<ReadBookClubMember> members) {
+        this.name = name;
+        this.status = status;
+        this.profileImgUrl = profileImgUrl;
+        this.createdTime = createdTime;
+        this.lastBook = readBookClubLastBook;
+        this.members = members;
+    }
+
+    @Getter
+    protected static class ReadBookClubLastBook {
+
+        private final String name;
+        private final String author;
+
+        protected ReadBookClubLastBook(String name, String author) {
+            this.name = name;
+            this.author = author;
+        }
+
+        protected static ReadBookClubLastBook from(Book book) {
+            return new ReadBookClubLastBook(book.getTitle(), book.getAuthor());
+        }
+
+    }
+
+    @Getter
+    protected static class ReadBookClubMember {
+
+        private final Long id;
+        private final String nickname;
+        private final String profileImgUrl;
+        private final String email;
+
+        @Builder
+        private ReadBookClubMember(Long id, String nickname, String profileImgUrl, String email) {
+            this.id = id;
+            this.nickname = nickname;
+            this.profileImgUrl = profileImgUrl;
+            this.email = email;
+        }
+
+        protected static List<ReadBookClubMember> from(List<Member> members) {
+            return members.stream()
+                    .map(ReadBookClubMember::from)
+                    .collect(Collectors.toUnmodifiableList());
+        }
+
+        private static ReadBookClubMember from(Member member) {
+            return ReadBookClubMember.builder()
+                    .id(member.getId())
+                    .nickname(member.getNickname())
+                    .profileImgUrl(member.getProfileImgUrl())
+                    .email(member.getEmail())
+                    .build();
+        }
+
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -61,9 +61,14 @@ public class BookClub {
     }
 
     public void updateUpcomingGatheringDate(LocalDateTime gatheringDate) {
-        if (gatheringDate.isBefore(upcomingGatheringDate)) {
+        if (upcomingGatheringDate == null || upcomingGatheringDate.isAfter(gatheringDate)) {
             upcomingGatheringDate = gatheringDate;
         }
+    }
+
+    public void close() {
+        this.bookClubStatus = BookClubStatus.CLOSED;
+        closedTime = LocalDateTime.now();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -1,5 +1,6 @@
 package codesquad.bookkbookk.domain.bookclub.data.entity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +11,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import org.hibernate.annotations.CreationTimestamp;
+
 import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 
 import lombok.AccessLevel;
@@ -33,6 +37,15 @@ public class BookClub {
     private String name;
     @Column(name = "profile_img_url", nullable = false)
     private String profileImgUrl;
+    @Column(name = "book_club_status", nullable = false)
+    private BookClubStatus bookClubStatus;
+    @CreationTimestamp
+    @Column(name = "created_time", nullable = false)
+    private LocalDateTime createdTime;
+    @Column(name = "closed_time")
+    private LocalDateTime closedTime;
+    @Column(name = "upcoming_gathering_date")
+    private LocalDateTime upcomingGatheringDate;
 
     @OneToMany(mappedBy = "bookClub")
     private List<BookClubMember> bookClubMembers = new ArrayList<>();
@@ -44,6 +57,7 @@ public class BookClub {
         this.creatorId = creatorId;
         this.name = name;
         this.profileImgUrl = profileImgUrl;
+        this.bookClubStatus = BookClubStatus.OPEN;
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -60,4 +60,10 @@ public class BookClub {
         this.bookClubStatus = BookClubStatus.OPEN;
     }
 
+    public void updateUpcomingGatheringDate(LocalDateTime gatheringDate) {
+        if (gatheringDate.isBefore(upcomingGatheringDate)) {
+            upcomingGatheringDate = gatheringDate;
+        }
+    }
+
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
@@ -1,0 +1,7 @@
+package codesquad.bookkbookk.domain.bookclub.data.type;
+
+public enum BookClubStatus {
+
+    OPEN, CLOSED
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
@@ -1,7 +1,25 @@
 package codesquad.bookkbookk.domain.bookclub.data.type;
 
+import codesquad.bookkbookk.domain.bookclub.data.dto.ClosedBookClubDetailResponse;
+import codesquad.bookkbookk.domain.bookclub.data.dto.OpenBookClubDetailResponse;
+import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+
 public enum BookClubStatus {
 
-    OPEN, CLOSED
+    OPEN {
+        @Override
+        public OpenBookClubDetailResponse from(BookClub bookClub) {
+            return OpenBookClubDetailResponse.from(bookClub);
+        }
+    },
+    CLOSED {
+        @Override
+        public ClosedBookClubDetailResponse from(BookClub bookClub) {
+            return ClosedBookClubDetailResponse.from(bookClub);
+        }
+    };
+
+    public abstract ReadBookClubDetailResponse from(BookClub bookClub);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -12,6 +12,7 @@ import codesquad.bookkbookk.common.error.exception.InvitationUrlNotFoundExceptio
 import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.image.S3ImageUploader;
 import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
+import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
 import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
 import codesquad.bookkbookk.domain.mapping.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateBookClubRequest;
@@ -125,6 +126,12 @@ public class BookClubService {
         });
 
         return JoinBookClubResponse.from(save);
+    }
+
+    public ReadBookClubDetailResponse readBookClubDetail(Long bookClubId) {
+        BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
+
+        return bookClub.getBookClubStatus().from(bookClub);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
@@ -6,6 +6,7 @@ import codesquad.bookkbookk.common.error.exception.BookNotFoundException;
 import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.gathering.data.dto.CreateGatheringRequest;
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.gathering.repository.GatheringRepository;
@@ -24,11 +25,14 @@ public class GatheringService {
     public void createGathering(CreateGatheringRequest createGatheringRequest, Long memberId) {
         Book book = bookRepository.findById(createGatheringRequest.getBookId())
                 .orElseThrow(BookNotFoundException::new);
-        authorizationService.authorizeBookClubMembership(memberId, book.getBookClub().getId());
+        BookClub bookClub = book.getBookClub();
+        authorizationService.authorizeBookClubMembership(memberId, bookClub.getId());
 
         Gathering gathering = new Gathering(book, createGatheringRequest.getDateTime(),
                 createGatheringRequest.getPlace());
         gatheringRepository.save(gathering);
+
+        bookClub.updateUpcomingGatheringDate(gathering.getDateTime());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -1,5 +1,8 @@
 package codesquad.bookkbookk.domain.mapping.entity;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -37,6 +40,12 @@ public class BookClubMember {
     public BookClubMember(BookClub bookClub, Member member) {
         this.bookClub = bookClub;
         this.member = member;
+    }
+
+    public static List<Member> toMembers(List<BookClubMember> bookClubMembers) {
+        return bookClubMembers.stream()
+                .map(BookClubMember::getMember)
+                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
+++ b/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
@@ -1,11 +1,14 @@
 package codesquad.bookkbookk.util;
 
+import java.time.LocalDateTime;
+
 import codesquad.bookkbookk.domain.auth.data.type.LoginType;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
@@ -90,4 +93,7 @@ public class TestDataFactory {
         return new Comment(bookmark, writer, "content");
     }
 
+    public static Gathering createGathering(Book book) {
+        return new Gathering(book, LocalDateTime.now(), "코드 스쿼드");
+    }
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

북클럽 상세 조회 기능을 구현했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 북클럽이 열린 상태인지, 닫힌 상태인지에 따라서 응답의 필드가 달라집니다. 그러나 대부분의 필드가 공통이라 ReadBookClubResponse라는 조상 객체를 만들고 공통 필드를 넣은 뒤, OpenBookClubDetailResponse, ClosedBookClubDetailResponse로 각각 만들었습니다. 그래서 api의 responseEntity를 만들 때 ReadBookResponse를 body로 넣어주어 상황에 맞는 응답을 만들도록 했습니다.
- BookClubStatus에서 추상 메서드를 선언하고 각 상태마다 메서드를 구현하여 상태에 맞는 응답을 만들도록 구현했습니다.
- 가독성을 위해 ReadBookClubResponse에 inner Class를 생성했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
