### PR TITLE
[BE] 챕터 조회 기능 수정

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/ChapterStatusNotFoundException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/ChapterStatusNotFoundException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ChapterStatusNotFoundException extends ApiException{
+
+    public ChapterStatusNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "Chapter Status를 찾을 수 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/controller/ChapterController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/controller/ChapterController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.domain.chapter.data.dto.CreateChapterRequest;
@@ -36,8 +37,8 @@ public class ChapterController {
     }
 
     @GetMapping("/{bookId}")
-    public ResponseEntity<List<ReadChapterResponse>> readChapters(@PathVariable Long bookId) {
-        List<ReadChapterResponse> response = chapterService.readChapters(bookId);
+    public ResponseEntity<List<ReadChapterResponse>> readChapters(@PathVariable Long bookId, @RequestParam int statusId) {
+        List<ReadChapterResponse> response = chapterService.readChapters(bookId, statusId);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/dto/ReadChapterResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/dto/ReadChapterResponse.java
@@ -3,17 +3,68 @@ package codesquad.bookkbookk.domain.chapter.data.dto;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
 public class ReadChapterResponse {
 
+    private final Long chapterId;
     private final String title;
-    private final int topicsCount;
+    private final Integer statusId;
+    private final List<ReadChapterTopicResponse> topics;
+
+    @AllArgsConstructor
+    @Getter
+    private static class ReadChapterTopicResponse {
+
+        private final Long topicId;
+        private final String title;
+        private final ReadChapterBookmarkResponse recentBookmark;
+
+        private static List<ReadChapterTopicResponse> from(List<Topic> topics) {
+            return topics.stream()
+                    .map(ReadChapterTopicResponse::from)
+                    .collect(Collectors.toUnmodifiableList());
+        }
+
+        private static ReadChapterTopicResponse from(Topic topic) {
+            List<Bookmark> bookmarks = topic.getBookmarks();
+
+            if (bookmarks.isEmpty()) {
+                return new  ReadChapterTopicResponse(topic.getId(), topic.getTitle(), null);
+            }
+            return new ReadChapterTopicResponse(topic.getId(), topic.getTitle(),
+                    ReadChapterBookmarkResponse.from(bookmarks.get(bookmarks.size() - 1)));
+        }
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class ReadChapterBookmarkResponse {
+
+        private final String authorProfileImgUrl;
+        private final String content;
+
+        private static ReadChapterBookmarkResponse from(Bookmark bookmark) {
+            return new ReadChapterBookmarkResponse(bookmark.getWriter().getProfileImgUrl(), bookmark.getContent());
+        }
+
+    }
+
+    @Builder
+    private ReadChapterResponse(Long chapterId, String title, Integer statusId, List<ReadChapterTopicResponse> topics) {
+        this.chapterId = chapterId;
+        this.title = title;
+        this.statusId = statusId;
+        this.topics = topics;
+    }
 
     public static List<ReadChapterResponse> from(List<Chapter> chapters) {
         return chapters.stream()
@@ -22,7 +73,12 @@ public class ReadChapterResponse {
     }
 
     private static ReadChapterResponse from(Chapter chapter) {
-        return new ReadChapterResponse(chapter.getTitle(), chapter.getTopics().size());
+        return ReadChapterResponse.builder()
+                .chapterId(chapter.getId())
+                .title(chapter.getTitle())
+                .statusId(chapter.getStatus().getId())
+                .topics(ReadChapterTopicResponse.from(chapter.getTopics()))
+                .build();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -35,6 +37,7 @@ public class Chapter {
     private Book book;
     private String title;
     @Column(name = "chapter_status")
+    @Enumerated(value = EnumType.STRING)
     private ChapterStatus status;
 
     @OneToMany(mappedBy = "chapter")

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -14,6 +14,7 @@ import javax.persistence.OneToMany;
 
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.chapter.data.dto.UpdateChapterTitleRequest;
+import codesquad.bookkbookk.domain.chapter.data.type.ChapterStatus;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 import lombok.AccessLevel;
@@ -29,12 +30,12 @@ public class Chapter {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chapter_id")
     private Long id;
-
     @ManyToOne
     @JoinColumn(name = "book_id")
     private Book book;
-
     private String title;
+    @Column(name = "chapter_status")
+    private ChapterStatus status;
 
     @OneToMany(mappedBy = "chapter")
     private List<Topic> topics = new ArrayList<>();
@@ -42,6 +43,7 @@ public class Chapter {
     public Chapter(Book book, String title) {
         this.book = book;
         this.title = title;
+        this.status = ChapterStatus.BEFORE_READING;
     }
 
     public void updateTitle(UpdateChapterTitleRequest updateChapterTitleRequest) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
@@ -1,0 +1,17 @@
+package codesquad.bookkbookk.domain.chapter.data.type;
+
+public enum ChapterStatus {
+
+    BEFORE_READING("독서 전", 1),
+    READING("독서 중", 2),
+    AFTER_READING("독서 완료", 3);
+
+    private final String name;
+    private final int id;
+
+    ChapterStatus(String name, int id) {
+        this.name = name;
+        this.id = id;
+    }
+}
+

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
@@ -1,5 +1,7 @@
 package codesquad.bookkbookk.domain.chapter.data.type;
 
+import codesquad.bookkbookk.common.error.exception.ChapterStatusNotFoundException;
+
 public enum ChapterStatus {
 
     BEFORE_READING("독서 전", 1),
@@ -12,6 +14,15 @@ public enum ChapterStatus {
     ChapterStatus(String name, int id) {
         this.name = name;
         this.id = id;
+    }
+
+    public static ChapterStatus of(int id) {
+        for (ChapterStatus status : ChapterStatus.values()) {
+            if (status.id == id) {
+                return status;
+            }
+        }
+        throw new ChapterStatusNotFoundException();
     }
 }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/type/ChapterStatus.java
@@ -2,6 +2,9 @@ package codesquad.bookkbookk.domain.chapter.data.type;
 
 import codesquad.bookkbookk.common.error.exception.ChapterStatusNotFoundException;
 
+import lombok.Getter;
+
+@Getter
 public enum ChapterStatus {
 
     BEFORE_READING("독서 전", 1),

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterRepository.java
@@ -5,9 +5,12 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.chapter.data.type.ChapterStatus;
 
 public interface ChapterRepository extends JpaRepository<Chapter, Long> {
 
     List<Chapter> findAllByBookId(Long bookId);
+
+    List<Chapter> findAllByBookIdAndStatus(Long BookId, ChapterStatus status);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
@@ -15,6 +15,7 @@ import codesquad.bookkbookk.domain.chapter.data.dto.CreateChapterResponse;
 import codesquad.bookkbookk.domain.chapter.data.dto.ReadChapterResponse;
 import codesquad.bookkbookk.domain.chapter.data.dto.UpdateChapterTitleRequest;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.chapter.data.type.ChapterStatus;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 import codesquad.bookkbookk.domain.topic.repository.TopicRepository;
@@ -24,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ChapterService {
+
+    private static final int ALL_STATUS = 0;
 
     private final ChapterRepository chapterRepository;
     private final TopicRepository topicRepository;
@@ -50,10 +53,12 @@ public class ChapterService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadChapterResponse> readChapters(Long bookId) {
-        List<Chapter> chapters = chapterRepository.findAllByBookId(bookId);
-
-        return ReadChapterResponse.from(chapters);
+    public List<ReadChapterResponse> readChapters(Long bookId, int chapterStatusId) {
+        if (chapterStatusId == ALL_STATUS) {
+            return ReadChapterResponse.from(chapterRepository.findAllByBookId(bookId));
+        }
+        ChapterStatus chapterStatus = ChapterStatus.of(chapterStatusId);
+        return ReadChapterResponse.from(chapterRepository.findAllByBookIdAndStatus(bookId, chapterStatus));
     }
 
     @Transactional

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -1,5 +1,8 @@
 package codesquad.bookkbookk.domain.topic.data.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -7,7 +10,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 
 import lombok.AccessLevel;
@@ -23,12 +28,13 @@ public class Topic {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "topic_id")
     private Long id;
-
     @ManyToOne
     @JoinColumn(name = "chapter_id")
     private Chapter chapter;
-
     private String title;
+
+    @OneToMany(mappedBy = "topic")
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     public Topic(Chapter chapter, String title) {
         this.chapter = chapter;

--- a/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
+++ b/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
@@ -1,6 +1,9 @@
 package codesquad.bookkbookk.util;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import codesquad.bookkbookk.domain.auth.data.type.LoginType;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
@@ -95,5 +98,16 @@ public class TestDataFactory {
 
     public static Gathering createGathering(Book book) {
         return new Gathering(book, LocalDateTime.now(), "코드 스쿼드");
+    }
+
+    public static List<Bookmark> createBookmarks(int count, Member writer, Topic topic) {
+        return IntStream.range(1, count + 1)
+                .mapToObj(index -> Bookmark.builder()
+                        .writer(writer)
+                        .topic(topic)
+                        .title("title" + index)
+                        .content("content" + index)
+                        .build())
+                .collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

프론트에서 필요한 정보를 주도록 메서드를 변경합니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

#### 구현 내용
- 엔티티 수정
  - topic의 필드에 bookmark list 추가
    - chapter에 status 추가
- ChpaterStatus에 statusId에 해당하는 ChapterStatus 탐색 메서드 구현
- ChapterController 수정
- ChapterService 변경
- response 객체 수정


#### 구현 설명
- ChapterStatus enum에 전체에 해당하는 이넘이 없습니다. 전체를 조회하는 경우(statusId = 0)는 ChapterSeivice에서 전체를 조회합니다. 상태의 개별조회(statusId = 1, 2, 3)의 경우에서는 id에 해당하는 enum을 사용하여 Chapter를 조회합니다. ChapterStatus에 전체 enum을 추가할 수도 있었지만, 추가한다면 db에 전체에 대응하는 enum이 들어갈 수 있는 문제가 있어 Service에서 처리했습니다.
- response 객체는 innver Class를 활용하여 구현했습니다. 데이터 계층이 depth가 있어서 한번에 응답을 보기 위해 이렇게 구현했습니다. 그리고 inner Class는 private으로 지정하여 클래스 외부에서 접근이 안되게 만들었습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
