### PR TITLE
[BE] 북클럽 상태를 이용한 북클럽 조회 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/BookClubStatusNotFoundException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/BookClubStatusNotFoundException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BookClubStatusNotFoundException extends ApiException {
+
+    public BookClubStatusNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "Book Club의 Status가 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
@@ -24,7 +24,6 @@ import codesquad.bookkbookk.domain.bookclub.data.dto.InvitationUrlResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
-import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.service.BookClubService;
 import codesquad.bookkbookk.domain.gathering.data.dto.CreateGatheringRequest;
 import codesquad.bookkbookk.domain.gathering.service.GatheringService;
@@ -50,8 +49,9 @@ public class BookClubController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ReadBookClubResponse>> readBookClubs(@MemberId Long memberId) {
-        List<ReadBookClubResponse> response = bookClubService.readBookClubs(memberId);
+    public ResponseEntity<List<ReadBookClubDetailResponse>> readBookClubs(@MemberId Long memberId,
+                                                                          @RequestParam String status) {
+        List<ReadBookClubDetailResponse> response = bookClubService.readBookClubs(memberId, status);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
@@ -28,7 +28,10 @@ public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse{
     }
 
     public static ClosedBookClubDetailResponse from(BookClub bookClub) {
-        Book lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
+        Book lastBook;
+        if (bookClub.getBooks().isEmpty()) {
+            lastBook = null;
+        } else lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
         List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
 
         return ClosedBookClubDetailResponse.builder()

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.domain.bookclub.data.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
@@ -39,6 +40,12 @@ public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse{
                 .readBookClubMembers(ReadBookClubMember.from(members))
                 .closedTime(bookClub.getClosedTime())
                 .build();
+    }
+
+    public static List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs) {
+        return bookClubs.stream()
+                .map(ClosedBookClubDetailResponse::from)
+                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.domain.bookclub.data.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
@@ -39,6 +40,12 @@ public class OpenBookClubDetailResponse extends ReadBookClubDetailResponse{
                 .readBookClubMembers(ReadBookClubMember.from(members))
                 .upcomingGatheringDate(bookClub.getUpcomingGatheringDate())
                 .build();
+    }
+
+    public static List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs) {
+        return bookClubs.stream()
+                .map(OpenBookClubDetailResponse::from)
+                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
@@ -28,7 +28,10 @@ public class OpenBookClubDetailResponse extends ReadBookClubDetailResponse{
     }
 
     public static OpenBookClubDetailResponse from(BookClub bookClub) {
-        Book lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
+        Book lastBook;
+        if (bookClub.getBooks().isEmpty()) {
+            lastBook = null;
+        } else lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
         List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
 
         return OpenBookClubDetailResponse.builder()

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
@@ -44,6 +44,9 @@ public class ReadBookClubDetailResponse {
         }
 
         protected static ReadBookClubLastBook from(Book book) {
+            if (book == null) {
+                return null;
+            }
             return new ReadBookClubLastBook(book.getTitle(), book.getAuthor());
         }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,6 +39,7 @@ public class BookClub {
     private String name;
     @Column(name = "profile_img_url", nullable = false)
     private String profileImgUrl;
+    @Enumerated(value = EnumType.STRING)
     @Column(name = "book_club_status", nullable = false)
     private BookClubStatus bookClubStatus;
     @CreationTimestamp

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
@@ -1,5 +1,8 @@
 package codesquad.bookkbookk.domain.bookclub.data.type;
 
+import java.util.List;
+
+import codesquad.bookkbookk.common.error.exception.BookClubStatusNotFoundException;
 import codesquad.bookkbookk.domain.bookclub.data.dto.ClosedBookClubDetailResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.OpenBookClubDetailResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
@@ -12,14 +15,37 @@ public enum BookClubStatus {
         public OpenBookClubDetailResponse from(BookClub bookClub) {
             return OpenBookClubDetailResponse.from(bookClub);
         }
+
+        @Override
+        public List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs) {
+            return OpenBookClubDetailResponse.from(bookClubs);
+        }
     },
     CLOSED {
         @Override
         public ClosedBookClubDetailResponse from(BookClub bookClub) {
             return ClosedBookClubDetailResponse.from(bookClub);
         }
+
+        @Override
+        public List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs) {
+            return ClosedBookClubDetailResponse.from(bookClubs);
+        }
     };
 
+    public static BookClubStatus of(String name) {
+        String upperCaseName = name.toUpperCase();
+
+        for (BookClubStatus status : BookClubStatus.values()) {
+            if (status.name().equals(upperCaseName)) {
+                return status;
+            }
+        }
+        throw new BookClubStatusNotFoundException();
+    }
+
     public abstract ReadBookClubDetailResponse from(BookClub bookClub);
+
+    public abstract List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -12,22 +12,22 @@ import codesquad.bookkbookk.common.error.exception.InvitationUrlNotFoundExceptio
 import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
 import codesquad.bookkbookk.common.image.S3ImageUploader;
 import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
-import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
-import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
-import codesquad.bookkbookk.domain.mapping.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateBookClubRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateInvitationUrlRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.InvitationUrlResponse;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubRequest;
 import codesquad.bookkbookk.domain.bookclub.data.dto.JoinBookClubResponse;
-import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubResponse;
+import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubDetailResponse;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClubInvitationCode;
-import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubInvitationCodeRepository;
-import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
+import codesquad.bookkbookk.domain.mapping.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 
@@ -40,6 +40,7 @@ public class BookClubService {
     private static final String DEFAULT_BOOK_CLUB_IMAGE_URL =
             "https://i.namu.wiki/i/ZnPxYijjK2AlXyf1dPZv0fqVvg3kdxahVkONYTCR-jplhh48smoq4UCfSAZIz6_R0lxoBz"
                     + "JuQiIL6kfwtv0taBXNa_-nOxJKx2BX-z3GxPj6vqoc14GZ7nrT_jDXlrOV1xNL9RVYBTN_brsnBuCwOA.webp";
+    private static final String STATUS_ALL = "all";
 
     private final AuthorizationService authorizationService;
 
@@ -78,13 +79,15 @@ public class BookClubService {
         return new CreateBookClubResponse(bookClub.getId(), invitationUrlResponse.getInvitationUrl());
     }
 
-    public List<ReadBookClubResponse> readBookClubs(Long memberId) {
+    public List<ReadBookClubDetailResponse> readBookClubs(Long memberId, String statusName) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        List<BookClub> bookClubs = member.getMemberBookClubs().stream()
-                .map(BookClubMember::getBookClub)
+
+        BookClubStatus status = BookClubStatus.of(statusName);
+        List<BookClub> filteredBookClubs = member.getBookClubs().stream()
+                .filter(bookClub -> bookClub.getBookClubStatus().equals(status))
                 .collect(Collectors.toUnmodifiableList());
 
-        return ReadBookClubResponse.from(bookClubs);
+        return status.from(filteredBookClubs);
     }
 
     public InvitationUrlResponse createInvitationUrl(Long memberId, CreateInvitationUrlRequest request) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -82,6 +82,12 @@ public class BookClubService {
     public List<ReadBookClubDetailResponse> readBookClubs(Long memberId, String statusName) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
+        if (statusName.equals(STATUS_ALL)) {
+            return  member.getBookClubs().stream()
+                    .map(bookClub -> bookClub.getBookClubStatus().from(bookClub))
+                    .collect(Collectors.toUnmodifiableList());
+        }
+
         BookClubStatus status = BookClubStatus.of(statusName);
         List<BookClub> filteredBookClubs = member.getBookClubs().stream()
                 .filter(bookClub -> bookClub.getBookClubStatus().equals(status))

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -2,6 +2,7 @@ package codesquad.bookkbookk.domain.member.data.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,6 +14,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import codesquad.bookkbookk.domain.auth.data.type.LoginType;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
 
@@ -58,6 +60,12 @@ public class Member {
 
     public void updateProfileImgUrl(String profileImgUrl){
         this.profileImgUrl = profileImgUrl;
+    }
+
+    public List<BookClub> getBookClubs() {
+        return memberBookClubs.stream()
+                .map(BookClubMember::getBookClub)
+                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/test/java/codesquad/bookkbookk/bookclub/integration/BookClubTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/bookclub/integration/BookClubTest.java
@@ -23,15 +23,14 @@ import codesquad.bookkbookk.common.jwt.JwtProvider;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.dto.CreateInvitationUrlRequest;
-import codesquad.bookkbookk.domain.bookclub.data.dto.ReadBookClubResponse;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClubInvitationCode;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubInvitationCodeRepository;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.gathering.data.dto.CreateGatheringRequest;
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.gathering.repository.GatheringRepository;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
-import codesquad.bookkbookk.domain.bookclub.repository.BookClubInvitationCodeRepository;
-import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
@@ -85,40 +84,6 @@ public class BookClubTest extends IntegrationTest {
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
             softAssertions.assertThat(response.jsonPath().getLong("bookClubId")).isEqualTo(member.getId());
-        });
-    }
-
-    @Test
-    @DisplayName("현재 로그인 한 유저의 북클럽을 조회한다.")
-    void readBookClubs() {
-        // given
-        Member member = TestDataFactory.createMember();
-        memberRepository.save(member);
-
-        BookClub bookClub = TestDataFactory.createBookClub();
-        bookClubRepository.save(bookClub);
-
-        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
-        bookClubMemberRepository.save(bookClubMember);
-
-        String accessToken = jwtProvider.createAccessToken(member.getId());
-
-        // when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .queryParam("status", "open")
-                .when()
-                .get("/api/book-clubs")
-                .then().log().all()
-                .extract();
-
-        // then
-        ReadBookClubResponse result = response.jsonPath().getList("", ReadBookClubResponse.class).get(0);
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            softAssertions.assertThat(result.getName()).isEqualTo(bookClub.getName());
-            softAssertions.assertThat(result.getCreatorId()).isEqualTo(member.getId());
         });
     }
 

--- a/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
+++ b/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
@@ -110,4 +110,12 @@ public class TestDataFactory {
                         .build())
                 .collect(Collectors.toUnmodifiableList());
     }
+
+    public static BookClub createDummyBookClub(int count) {
+        return BookClub.builder()
+                .creatorId(1L)
+                .name("Test Book Club" + count)
+                .profileImgUrl("image.url")
+                .build();
+    }
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- 북클럽 상태를 이용하여 멤버의 북클럽을 조회합니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 모든 북클럽(open과 closed 둘다)을 조회할 때 모든 상태에 해당하는 이넘을 만들지 않고 service layer에서 status를 확인하고 처리했습니다. 이것은 이넘을 추가하여 모두에 해당하는 status가 db에 저장되는 것을 방지하기 위함입니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
