### PR TITLE
[BE] 멤버 책 조회에서 책의 statusId 주입

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/dto/ReadBookResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/dto/ReadBookResponse.java
@@ -49,6 +49,7 @@ public class ReadBookResponse {
     public static class BookResponse {
 
         private final Long id;
+        private final Integer statusId;
         private final String isbn;
         private final BookClubResponse bookClub;
         private final String title;
@@ -57,9 +58,10 @@ public class ReadBookResponse {
         private final String category;
 
         @Builder
-        private BookResponse(Long id, String isbn, BookClubResponse bookClubResponse, String title,
+        private BookResponse(Long id, Integer statusId, String isbn, BookClubResponse bookClubResponse, String title,
                              String cover, String author, String category) {
             this.id = id;
+            this.statusId = statusId;
             this.isbn = isbn;
             this.bookClub = bookClubResponse;
             this.title = title;
@@ -71,6 +73,7 @@ public class ReadBookResponse {
         private static BookResponse from(Book book) {
             return BookResponse.builder()
                     .id(book.getId())
+                    .statusId(book.getStatus().getId())
                     .isbn(book.getIsbn())
                     .bookClubResponse(BookClubResponse.from(book.getBookClub()))
                     .title(book.getTitle())

--- a/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/member/integration/MemberTest.java
@@ -163,8 +163,12 @@ public class MemberTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            softAssertions.assertThat(((LinkedHashMap) response.jsonPath().getList("books").get(0)).get("title"))
+            softAssertions.assertThat(response.jsonPath().getMap("pagination").get("totalPageCounts"))
+                    .isEqualTo(2);
+            softAssertions.assertThat(((LinkedHashMap<?, ?>) response.jsonPath().getList("books").get(0)).get("title"))
                     .isEqualTo("신데렐라");
+            softAssertions.assertThat(((LinkedHashMap<?, ?>) response.jsonPath().getList("books").get(0)).get("statusId"))
+                    .isEqualTo(1);
         });
     }
 


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

-  멤버 책 조회에서 책의 statusId를 주입했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

<!-- 구현한 기능에서 본인의 생각한 과정을 중심으로 써주세요. --->

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
