### PR TITLE
BE: 인가 기능 추가

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/MemberNotInBookClubException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/MemberNotInBookClubException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public class MemberNotInBookClubException extends ApiException {
 
     public MemberNotInBookClubException() {
-        super(HttpStatus.UNAUTHORIZED, "해당 북클럽에 권한이 없습니다.");
+        super(HttpStatus.FORBIDDEN, "해당 북클럽의 권한이 없습니다.");
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/entity/MemberRefreshToken.java
@@ -5,16 +5,12 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
-
-import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "member_refresh_token")
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberRefreshToken {

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationRepository.java
@@ -1,0 +1,157 @@
+package codesquad.bookkbookk.domain.auth.repository;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthorizationRepository {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    public boolean existsBookClubMemberByMemberIdAndBookClubId(Long memberId, Long bookClubId) {
+        String nativeQuery = "SELECT bookClubMember.id " +
+                "FROM BookClubMember AS bookClubMember " +
+                "WHERE bookClubMember.bookClub.id = :bookClubId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("bookClubId", bookClubId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndBookId(Long memberId, Long bookId) {
+        String nativeQuery = "SELECT book.id " +
+                "FROM Book AS book " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON bookClubMember.bookClub.id = book.bookClub.id " +
+                "WHERE book.id = :bookId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("bookId", bookId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndGatheringId(Long memberId, Long gatheringId) {
+        String nativeQuery = "SELECT gathering.id " +
+                "FROM Gathering AS gathering " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON bookClubMember.bookClub.id = gathering.book.bookClub.id " +
+                "WHERE gathering.id = :gatheringId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("gatheringId", gatheringId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndChapterId(Long memberId, Long chapterId) {
+        String nativeQuery = "SELECT chapter.id " +
+                "FROM Chapter AS chapter " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON chapter.book.bookClub.id = bookClubMember.bookClub.id " +
+                "WHERE chapter.id = :chapterId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("chapterId", chapterId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndTopicId(Long memberId, Long topicId) {
+        String nativeQuery = "SELECT topic.id " +
+                "FROM Topic AS topic " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON topic.chapter.book.bookClub.id = bookClubMember.bookClub.id " +
+                "WHERE topic.id = :topicId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("topicId", topicId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndBookmarkId(Long memberId, Long bookmarkId) {
+        String nativeQuery = "SELECT bookmark.id " +
+                "FROM Bookmark AS bookmark " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON bookmark.topic.chapter.book.bookClub.id = bookClubMember.bookClub.id " +
+                "WHERE bookmark.id = :bookmarkId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("bookmarkId", bookmarkId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookClubMemberByMemberIdAndCommentId(Long memberId, Long commentId) {
+        String nativeQuery = "SELECT comment.id " +
+                "FROM Comment AS comment " +
+                "INNER JOIN BookClubMember AS bookClubMember " +
+                    "ON comment.bookmark.topic.chapter.book.bookClub.id = bookClubMember.bookClub.id " +
+                "WHERE comment.id = :commentId " +
+                    "AND bookClubMember.member.id = :memberId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("commentId", commentId)
+                .setParameter("memberId", memberId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsBookmarkByIdAndWriterId(Long bookmarkId, Long writerId) {
+        String nativeQuery = "SELECT bookmark.id " +
+                "FROM Bookmark AS bookmark " +
+                "WHERE bookmark.id = :bookmarkId " +
+                    "AND bookmark.writer.id = :writerId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("bookmarkId", bookmarkId)
+                .setParameter("writerId", writerId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+    public boolean existsCommentByIdAndWriterId(Long commentId, Long writerId) {
+        String nativeQuery = "SELECT comment.id " +
+                "FROM Comment as comment " +
+                "WHERE comment.id = :commentId " +
+                    "AND comment.writer.id = :writerId";
+
+        List<?> foundIds = entityManager.createQuery(nativeQuery)
+                .setParameter("commentId", commentId)
+                .setParameter("writerId", writerId)
+                .setMaxResults(1)
+                .getResultList();
+        return !foundIds.isEmpty();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
@@ -7,9 +7,7 @@ import codesquad.bookkbookk.common.error.exception.MemberIsNotBookmarkWriterExce
 import codesquad.bookkbookk.common.error.exception.MemberIsNotCommentWriterException;
 import codesquad.bookkbookk.common.error.exception.MemberJoinedBookClubException;
 import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
-import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
-import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
-import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
+import codesquad.bookkbookk.domain.auth.repository.AuthorizationRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,34 +15,74 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthorizationService {
 
-    private final BookClubMemberRepository bookClubMemberRepository;
-    private final BookmarkRepository bookmarkRepository;
-    private final CommentRepository commentRepository;
+    private final AuthorizationRepository authorizationRepository;
 
     @Transactional(readOnly = true)
-    public void authorizeBookClubMembership(Long memberId, Long bookClubId) {
-        if (!bookClubMemberRepository.existsByBookClubIdAndMemberId(bookClubId, memberId)) {
+    public void authorizeBookClubMembershipByBookClubId(Long memberId, Long bookClubId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndBookClubId(memberId, bookClubId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByBookId(Long memberId, Long bookId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndBookId(memberId, bookId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByGatheringId(Long memberId, Long gatheringId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndGatheringId(memberId, gatheringId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByChapterId(Long memberId, Long chapterId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndChapterId(memberId, chapterId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByTopicId(Long memberId, Long topicId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndTopicId(memberId, topicId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByBookmarkId(Long memberId, Long bookmarkId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndBookmarkId(memberId, bookmarkId)) {
+            throw new MemberNotInBookClubException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByCommentId(Long memberId, Long commentId) {
+        if (!authorizationRepository.existsBookClubMemberByMemberIdAndCommentId(memberId, commentId)) {
             throw new MemberNotInBookClubException();
         }
     }
 
     @Transactional(readOnly = true)
     public void authorizeBookClubJoin(Long memberId, Long bookClubId) {
-        if (bookClubMemberRepository.existsByBookClubIdAndMemberId(bookClubId, memberId)) {
+        if (authorizationRepository.existsBookClubMemberByMemberIdAndBookClubId(memberId, bookClubId)) {
             throw new MemberJoinedBookClubException();
         }
     }
 
     @Transactional(readOnly = true)
-    public void authorizeBookmarkWriter(Long memberId, Long bookmarkId) {
-        if (!bookmarkRepository.existsByIdAndWriterId(bookmarkId, memberId)) {
+    public void authorizeBookmarkWriter(Long writerId, Long bookmarkId) {
+        if (!authorizationRepository.existsBookmarkByIdAndWriterId(bookmarkId, writerId)) {
             throw new MemberIsNotBookmarkWriterException();
         }
     }
 
     @Transactional(readOnly = true)
-    public void authorizeCommentWriter(Long memberId, Long bookmarkId) {
-        if (!commentRepository.existsByIdAndWriterId(bookmarkId, memberId)) {
+    public void authorizeCommentWriter(Long writerId, Long commentId) {
+        if (!authorizationRepository.existsCommentByIdAndWriterId(commentId, writerId)) {
             throw new MemberIsNotCommentWriterException();
         }
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/controller/BookController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/controller/BookController.java
@@ -41,17 +41,18 @@ public class BookController {
     }
 
     @GetMapping("/{bookId}/chapters")
-    public ResponseEntity<List<ReadChapterResponse>> readChapters(@PathVariable Long bookId, @RequestParam int statusId) {
-        List<ReadChapterResponse> response = chapterService.readChapters(bookId, statusId);
+    public ResponseEntity<List<ReadChapterResponse>> readChapters(@MemberId Long memberId, @PathVariable Long bookId,
+                                                                  @RequestParam int statusId) {
+        List<ReadChapterResponse> response = chapterService.readChapters(memberId, bookId, statusId);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @PatchMapping("/{bookId}")
-    public ResponseEntity<UpdateBookStatusResponse> updateBookStatus(@PathVariable Long bookId,
+    public ResponseEntity<UpdateBookStatusResponse> updateBookStatus(@MemberId Long memberId, @PathVariable Long bookId,
                                                                      @RequestBody UpdateBookStatusRequest request) {
-        UpdateBookStatusResponse response = bookService.updateBookStatus(bookId, request);
+        UpdateBookStatusResponse response = bookService.updateBookStatus(memberId, bookId, request);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
@@ -11,9 +11,9 @@ import codesquad.bookkbookk.domain.book.data.entity.Book;
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     @Query("SELECT book FROM Book book " +
-            "JOIN member_book member_book " +
-            "ON book.id = member_book.book.id " +
-            "WHERE member_book.member.id = :memberId")
+            "JOIN MemberBook AS memberBook " +
+            "ON book.id = memberBook.book.id " +
+            "WHERE memberBook.member.id = :memberId")
     Page<Book> findBooksByMemberId(Long memberId, Pageable pageable);
     Slice<Book> findBooksByBookClubId(Long bookClubId, Pageable pageable);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -39,7 +39,7 @@ public class BookService {
     private final MemberBookRepository memberBookRepository;
 
     public CreateBookResponse createBook(Long memberId, CreateBookRequest request) {
-        authorizationService.authorizeBookClubMembership(memberId, request.getBookClubId());
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, request.getBookClubId());
 
         BookClub bookclub = bookClubRepository.findById(request.getBookClubId())
                 .orElseThrow(BookClubNotFoundException::new);
@@ -67,14 +67,17 @@ public class BookService {
         return ReadBookResponse.from(books);
     }
 
-    public ReadBookClubBookResponse readBookClubBooks(Long bookClubId, Pageable pageable) {
-        Slice<Book> books = bookRepository.findBooksByBookClubId(bookClubId, pageable);
+    public ReadBookClubBookResponse readBookClubBooks(Long memberId, Long bookClubId, Pageable pageable) {
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 
+        Slice<Book> books = bookRepository.findBooksByBookClubId(bookClubId, pageable);
         return ReadBookClubBookResponse.from(books);
     }
 
     @Transactional
-    public UpdateBookStatusResponse updateBookStatus(Long bookId, UpdateBookStatusRequest request) {
+    public UpdateBookStatusResponse updateBookStatus(Long memberId, Long bookId, UpdateBookStatusRequest request) {
+        authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
+
         Book book = bookRepository.findById(bookId).orElseThrow(BookNotFoundException::new);
 
         book.updateStatus(request);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/controller/BookClubController.java
@@ -86,18 +86,21 @@ public class BookClubController {
     }
 
     @GetMapping("/{bookClubId}/books")
-    public ResponseEntity<ReadBookClubBookResponse> readBookClubBooks(@PathVariable Long bookClubId, @RequestParam Integer cursor,
-                                                         @RequestParam Integer size) {
+    public ResponseEntity<ReadBookClubBookResponse> readBookClubBooks(@MemberId Long memberId,
+                                                                      @PathVariable Long bookClubId,
+                                                                      @RequestParam Integer cursor,
+                                                                      @RequestParam Integer size) {
         Pageable pageable = PageRequest.of(cursor, size);
-        ReadBookClubBookResponse response = bookService.readBookClubBooks(bookClubId, pageable);
+        ReadBookClubBookResponse response = bookService.readBookClubBooks(memberId, bookClubId, pageable);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @GetMapping("/{bookClubId}")
-    public ResponseEntity<ReadBookClubDetailResponse> readBookClubDetail(@PathVariable Long bookClubId) {
-        ReadBookClubDetailResponse response = bookClubService.readBookClubDetail(bookClubId);
+    public ResponseEntity<ReadBookClubDetailResponse> readBookClubDetail(@MemberId Long memberId,
+                                                                         @PathVariable Long bookClubId) {
+        ReadBookClubDetailResponse response = bookClubService.readBookClubDetail(memberId, bookClubId);
 
         return ResponseEntity.ok()
                 .body(response);
@@ -112,8 +115,9 @@ public class BookClubController {
     }
 
     @GetMapping("/{bookClubId}/gatherings")
-    public ResponseEntity<List<ReadGatheringResponse>> readGatherings(@PathVariable Long bookClubId) {
-        List<ReadGatheringResponse> responses = gatheringService.readGatherings(bookClubId);
+    public ResponseEntity<List<ReadGatheringResponse>> readGatherings(@MemberId Long memberId,
+                                                                      @PathVariable Long bookClubId) {
+        List<ReadGatheringResponse> responses = gatheringService.readGatherings(memberId, bookClubId);
 
         return ResponseEntity.ok()
                 .body(responses);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubRepository.java
@@ -10,9 +10,9 @@ import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 public interface BookClubRepository extends JpaRepository<BookClub, Long> {
 
     @Query("SELECT bookclub FROM BookClub bookclub " +
-            "JOIN book_club_member book_club_member " +
-            "ON bookclub.id = book_club_member.bookClub.id " +
-            "WHERE book_club_member .member.id = :memberId")
+            "JOIN BookClubMember AS bookClubMember " +
+            "ON bookclub.id = bookClubMember.bookClub.id " +
+            "WHERE bookClubMember.member.id = :memberId")
     List<BookClub> findBookClubsByMemberId(Long memberId);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -97,7 +97,7 @@ public class BookClubService {
     }
 
     public InvitationUrlResponse createInvitationUrl(Long memberId, CreateInvitationUrlRequest request) {
-        authorizationService.authorizeBookClubMembership(memberId, request.getBookClubId());
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, request.getBookClubId());
 
         String invitationCode = String.valueOf(UUID.randomUUID());
         BookClubInvitationCode bookClubInvitationCode = new BookClubInvitationCode(request.getBookClubId(),
@@ -108,7 +108,7 @@ public class BookClubService {
     }
 
     public InvitationUrlResponse readInvitationUrl(Long memberId, Long bookClubId) {
-        authorizationService.authorizeBookClubMembership(memberId, bookClubId);
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 
         BookClubInvitationCode bookClubInvitationCode = bookClubInvitationCodeRepository.findByBookClubId(bookClubId)
                 .orElseThrow(InvitationUrlNotFoundException::new);
@@ -137,7 +137,9 @@ public class BookClubService {
         return JoinBookClubResponse.from(save);
     }
 
-    public ReadBookClubDetailResponse readBookClubDetail(Long bookClubId) {
+    public ReadBookClubDetailResponse readBookClubDetail(Long memberId, Long bookClubId) {
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+
         BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
 
         return bookClub.getBookClubStatus().from(bookClub);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/controller/BookmarkController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/controller/BookmarkController.java
@@ -72,16 +72,17 @@ public class BookmarkController {
     }
 
     @GetMapping("/{bookmarkId}/comments")
-    public ResponseEntity<List<ReadCommentResponse>> readComments(@PathVariable Long bookmarkId) {
-        List<ReadCommentResponse> responses = commentService.readComments(bookmarkId);
+    public ResponseEntity<List<ReadCommentResponse>> readComments(@MemberId Long memberId,
+                                                                  @PathVariable Long bookmarkId) {
+        List<ReadCommentResponse> responses = commentService.readComments(memberId, bookmarkId);
 
         return ResponseEntity.ok()
                 .body(responses);
     }
 
     @GetMapping("/{bookmarkId}/reactions")
-    public ResponseEntity<ReadReactionsResponse> readReactions(@PathVariable Long bookmarkId) {
-        ReadReactionsResponse response = bookmarkService.readBookmarkReactions(bookmarkId);
+    public ResponseEntity<ReadReactionsResponse> readReactions(@MemberId Long memberId, @PathVariable Long bookmarkId) {
+        ReadReactionsResponse response = bookmarkService.readBookmarkReactions(memberId, bookmarkId);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
@@ -41,6 +41,8 @@ public class BookmarkService {
 
     @Transactional
     public void createBookmark(Long memberId, CreateBookmarkRequest createBookmarkRequest) {
+        authorizationService.authorizeBookClubMembershipByTopicId(memberId, createBookmarkRequest.getTopicId());
+
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Topic topic = topicRepository.findById(createBookmarkRequest.getTopicId())
                 .orElseThrow(TopicNotFoundException::new);
@@ -72,6 +74,8 @@ public class BookmarkService {
 
     @Transactional
     public void createBookmarkReaction(Long memberId, Long bookmarkId, CreateBookmarkReactionRequest request) {
+        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+
         Reaction reaction = Reaction.of(request.getReactionName());
         if (bookmarkReactionRepository.existsByBookmarkIdAndReactorIdAndReaction(bookmarkId, memberId, reaction)) {
             throw new BookmarkReactionExistsException();
@@ -96,7 +100,9 @@ public class BookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public ReadReactionsResponse readBookmarkReactions(Long bookmarkId) {
+    public ReadReactionsResponse readBookmarkReactions(Long memberId, Long bookmarkId) {
+        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(BookmarkNotFoundException::new);
         List<BookmarkReaction> bookmarkReactions = bookmark.getBookmarkReactions();
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/controller/ChapterController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/controller/ChapterController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.bookkbookk.common.resolver.MemberId;
 import codesquad.bookkbookk.domain.chapter.data.dto.CreateChapterRequest;
 import codesquad.bookkbookk.domain.chapter.data.dto.CreateChapterResponse;
 import codesquad.bookkbookk.domain.chapter.data.dto.UpdateChapterRequest;
@@ -31,32 +32,33 @@ public class ChapterController {
     private final TopicService topicService;
 
     @PostMapping
-    public ResponseEntity<CreateChapterResponse> createChapter(@RequestBody CreateChapterRequest request) {
-        CreateChapterResponse response = chapterService.createChapter(request);
+    public ResponseEntity<CreateChapterResponse> createChapter(@MemberId Long memberId,
+                                                               @RequestBody CreateChapterRequest request) {
+        CreateChapterResponse response = chapterService.createChapter(memberId, request);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @PatchMapping("/{chapterId}")
-    public ResponseEntity<UpdateChapterResponse> updateChapter(@PathVariable Long chapterId,
+    public ResponseEntity<UpdateChapterResponse> updateChapter(@MemberId Long memberId, @PathVariable Long chapterId,
                                                                @RequestBody UpdateChapterRequest request) {
-        UpdateChapterResponse response = chapterService.updateChapter(chapterId, request);
+        UpdateChapterResponse response = chapterService.updateChapter(memberId, chapterId, request);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @DeleteMapping("/{chapterId}")
-    public ResponseEntity<Void> deleteChapter(@PathVariable Long chapterId) {
-        chapterService.deleteChapter(chapterId);
+    public ResponseEntity<Void> deleteChapter(@MemberId Long memberId, @PathVariable Long chapterId) {
+        chapterService.deleteChapter(memberId, chapterId);
 
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{chapterId}/topics")
-    public ResponseEntity<List<ReadTopicResponse>> readTopicList(@PathVariable Long chapterId) {
-        List<ReadTopicResponse> responses = topicService.readTopicLIst(chapterId);
+    public ResponseEntity<List<ReadTopicResponse>> readTopicList(@MemberId Long memberId, @PathVariable Long chapterId) {
+        List<ReadTopicResponse> responses = topicService.readTopicLIst(memberId, chapterId);
 
         return ResponseEntity.ok()
                 .body(responses);

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import codesquad.bookkbookk.common.error.exception.BookNotFoundException;
 import codesquad.bookkbookk.common.error.exception.ChapterNotFoundException;
 import codesquad.bookkbookk.common.type.Status;
+import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.chapter.data.dto.CreateChapterRequest;
@@ -29,12 +30,16 @@ public class ChapterService {
 
     private static final int ALL_STATUS = 0;
 
+    private final AuthorizationService authorizationService;
+
     private final ChapterRepository chapterRepository;
     private final TopicRepository topicRepository;
     private final BookRepository bookRepository;
 
     @Transactional
-    public CreateChapterResponse createChapter(CreateChapterRequest request) {
+    public CreateChapterResponse createChapter(Long memberId, CreateChapterRequest request) {
+        authorizationService.authorizeBookClubMembershipByBookId(memberId, request.getBookId());
+
         Book book = bookRepository.findById(request.getBookId()).orElseThrow(BookNotFoundException::new);
         List<CreateChapterRequest.ChapterDataDTO> dataList = request.toEntities(book);
 
@@ -54,7 +59,9 @@ public class ChapterService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadChapterResponse> readChapters(Long bookId, int chapterStatusId) {
+    public List<ReadChapterResponse> readChapters(Long memberId, Long bookId, int chapterStatusId) {
+        authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
+
         if (chapterStatusId == ALL_STATUS) {
             return ReadChapterResponse.from(chapterRepository.findAllByBookId(bookId));
         }
@@ -63,7 +70,9 @@ public class ChapterService {
     }
 
     @Transactional
-    public UpdateChapterResponse updateChapter(Long chapterId, UpdateChapterRequest request) {
+    public UpdateChapterResponse updateChapter(Long memberId, Long chapterId, UpdateChapterRequest request) {
+        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+
         Chapter chapter = chapterRepository.findById(chapterId).orElseThrow(ChapterNotFoundException::new);
 
         Chapter updated = chapter.update(request);
@@ -71,7 +80,9 @@ public class ChapterService {
     }
 
     @Transactional
-    public void deleteChapter(Long chapterId) {
+    public void deleteChapter(Long memberId, Long chapterId) {
+        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+
         chapterRepository.deleteById(chapterId);
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/controller/CommentController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/controller/CommentController.java
@@ -67,8 +67,8 @@ public class CommentController {
     }
 
     @GetMapping("/{commentId}/reactions")
-    public ResponseEntity<ReadReactionsResponse> readReactions(@PathVariable Long commentId) {
-        ReadReactionsResponse response = commentService.readBookmarkReactions(commentId);
+    public ResponseEntity<ReadReactionsResponse> readReactions(@MemberId Long memberId, @PathVariable Long commentId) {
+        ReadReactionsResponse response = commentService.readCommentReactions(memberId, commentId);
 
         return ResponseEntity.ok()
                 .body(response);

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
@@ -42,6 +42,8 @@ public class CommentService {
 
     @Transactional
     public void createComment(Long memberId, CreateCommentRequest createCommentRequest) {
+        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, createCommentRequest.getBookmarkId());
+
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Bookmark bookmark = bookmarkRepository.findById(createCommentRequest.getBookmarkId())
                 .orElseThrow(BookmarkNotFoundException::new);
@@ -68,6 +70,8 @@ public class CommentService {
 
     @Transactional
     public void createCommentReaction(Long memberId, Long commentId, CreateCommentReactionRequest request) {
+        authorizationService.authorizeBookClubMembershipByCommentId(memberId, commentId);
+
         Reaction reaction = Reaction.of(request.getReactionName());
         if (commentReactionRepository.existsByCommentIdAndReactorIdAndReaction(commentId, memberId, reaction)) {
             throw new CommentReactionExistsException();
@@ -92,14 +96,18 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadCommentResponse> readComments(Long bookmarkId) {
+    public List<ReadCommentResponse> readComments(Long memberId, Long bookmarkId) {
+        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(BookmarkNotFoundException::new);
 
         return ReadCommentResponse.from(bookmark.getComments());
     }
 
     @Transactional(readOnly = true)
-    public ReadReactionsResponse readBookmarkReactions(Long commentId) {
+    public ReadReactionsResponse readCommentReactions(Long memberId, Long commentId) {
+        authorizationService.authorizeBookClubMembershipByCommentId(memberId, commentId);
+
         Comment comment = commentRepository.findById(commentId).orElseThrow(BookmarkNotFoundException::new);
         List<CommentReaction> commentReactions = comment.getCommentReactions();
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/controller/GatheringController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/controller/GatheringController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.bookkbookk.common.resolver.MemberId;
 import codesquad.bookkbookk.domain.gathering.data.dto.UpdateGatheringRequest;
 import codesquad.bookkbookk.domain.gathering.data.dto.UpdateGatheringResponse;
 import codesquad.bookkbookk.domain.gathering.service.GatheringService;
@@ -22,17 +23,18 @@ public class GatheringController {
     private final GatheringService gatheringService;
 
     @PatchMapping("/{gatheringId}")
-    public ResponseEntity<UpdateGatheringResponse> updateGathering(@PathVariable Long gatheringId,
+    public ResponseEntity<UpdateGatheringResponse> updateGathering(@MemberId Long memberId,
+                                                                   @PathVariable Long gatheringId,
                                                                    @RequestBody UpdateGatheringRequest request) {
-        UpdateGatheringResponse response = gatheringService.updateGathering(gatheringId, request);
+        UpdateGatheringResponse response = gatheringService.updateGathering(memberId, gatheringId, request);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @DeleteMapping("/{gatheringId}")
-    public ResponseEntity<Void> deleteGathering(@PathVariable Long gatheringId) {
-        gatheringService.deleteGathering(gatheringId);
+    public ResponseEntity<Void> deleteGathering(@MemberId Long memberId, @PathVariable Long gatheringId) {
+        gatheringService.deleteGathering(memberId, gatheringId);
 
         return ResponseEntity.ok().build();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
@@ -35,9 +35,10 @@ public class GatheringService {
 
     @Transactional
     public void createGathering(Long memberId, Long bookClubId, CreateGatheringRequest request) {
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+
         Book book = bookRepository.findById(request.getBookId()).orElseThrow(BookNotFoundException::new);
         BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
-        authorizationService.authorizeBookClubMembership(memberId, bookClub.getId());
 
         Gathering gathering = new Gathering(book, request.getDateTime(), request.getPlace());
         gatheringRepository.save(gathering);
@@ -46,7 +47,9 @@ public class GatheringService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadGatheringResponse> readGatherings(Long bookClubId) {
+    public List<ReadGatheringResponse> readGatherings(Long memberId, Long bookClubId) {
+        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+
         BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
         List<Gathering> gatherings = bookClub.getBooks().stream()
                 .flatMap(book -> book.getGatherings().stream())
@@ -56,7 +59,9 @@ public class GatheringService {
     }
 
     @Transactional
-    public UpdateGatheringResponse updateGathering(Long gatheringId, UpdateGatheringRequest request) {
+    public UpdateGatheringResponse updateGathering(Long memberId, Long gatheringId, UpdateGatheringRequest request) {
+        authorizationService.authorizeBookClubMembershipByGatheringId(memberId, gatheringId);
+
         Gathering gathering = gatheringRepository.findById(gatheringId).orElseThrow(GatheringNotFoundException::new);
 
         gathering.update(request);
@@ -64,7 +69,9 @@ public class GatheringService {
     }
 
     @Transactional
-    public void deleteGathering(Long gatheringId) {
+    public void deleteGathering(Long memberId, Long gatheringId) {
+        authorizationService.authorizeBookClubMembershipByGatheringId(memberId, gatheringId);
+
         gatheringRepository.deleteById(gatheringId);
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -20,7 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "book_club_member")
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -18,7 +18,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "comment_reaction")
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CommentReaction {

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -15,7 +15,7 @@ import codesquad.bookkbookk.domain.member.data.entity.Member;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "member_book")
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberBook {
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/controller/TopicController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/controller/TopicController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.bookkbookk.common.resolver.MemberId;
 import codesquad.bookkbookk.domain.topic.data.dto.CreateTopicRequest;
 import codesquad.bookkbookk.domain.topic.data.dto.CreateTopicResponse;
 import codesquad.bookkbookk.domain.topic.data.dto.UpdateTopicTitleRequest;
@@ -24,25 +25,26 @@ public class TopicController {
     private final TopicService topicService;
 
     @PostMapping
-    public ResponseEntity<CreateTopicResponse> createTopic(@RequestBody CreateTopicRequest request) {
-        CreateTopicResponse response = topicService.createTopic(request);
+    public ResponseEntity<CreateTopicResponse> createTopic(@MemberId Long memberId,
+                                                           @RequestBody CreateTopicRequest request) {
+        CreateTopicResponse response = topicService.createTopic(memberId, request);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @PatchMapping("/{topicId}")
-    public ResponseEntity<Void> updateTitle(@PathVariable Long topicId,
-                                              @RequestBody UpdateTopicTitleRequest request) {
-        topicService.updateTitle(topicId, request);
+    public ResponseEntity<Void> updateTitle(@MemberId Long memberId, @PathVariable Long topicId,
+                                            @RequestBody UpdateTopicTitleRequest request) {
+        topicService.updateTitle(memberId, topicId, request);
 
         return ResponseEntity.ok()
                 .build();
     }
 
     @DeleteMapping("/{topicId}")
-    public ResponseEntity<Void> deleteTopic(@PathVariable Long topicId) {
-        topicService.deleteTopic(topicId);
+    public ResponseEntity<Void> deleteTopic(@MemberId Long memberId, @PathVariable Long topicId) {
+        topicService.deleteTopic(memberId, topicId);
 
         return ResponseEntity.ok()
                 .build();

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.bookkbookk.common.error.exception.ChapterNotFoundException;
 import codesquad.bookkbookk.common.error.exception.TopicNotFoundException;
+import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
 import codesquad.bookkbookk.domain.topic.data.dto.CreateTopicRequest;
@@ -22,31 +23,43 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TopicService {
 
+    private final AuthorizationService authorizationService;
+
     private final TopicRepository topicRepository;
     private final ChapterRepository chapterRepository;
 
     @Transactional
-    public CreateTopicResponse createTopic(CreateTopicRequest request) {
+    public CreateTopicResponse createTopic(Long memberId, CreateTopicRequest request) {
+        authorizationService.authorizeBookClubMembershipByChapterId(memberId, request.getChapterId());
+
         Chapter chapter = chapterRepository.findById(request.getChapterId())
                 .orElseThrow(ChapterNotFoundException::new);
+
         Topic topic = new Topic(chapter, request.getTitle());
         topicRepository.save(topic);
         return new CreateTopicResponse(topic.getId());
     }
 
-    public List<ReadTopicResponse> readTopicLIst(Long chapterId) {
+    public List<ReadTopicResponse> readTopicLIst(Long memberId, Long chapterId) {
+        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+
         List<Topic> topicList = topicRepository.findByChapterId(chapterId);
 
         return ReadTopicResponse.from(topicList);
     }
 
     @Transactional(readOnly = false)
-    public void updateTitle(Long topicId, UpdateTopicTitleRequest request) {
+    public void updateTitle(Long memberId, Long topicId, UpdateTopicTitleRequest request) {
+        authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
+
         Topic topic = topicRepository.findById(topicId).orElseThrow(TopicNotFoundException::new);
+
         topic.updateTitle(request.getTitle());
     }
 
-    public void deleteTopic(Long topicId) {
+    public void deleteTopic(Long memberId, Long topicId) {
+        authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
+
         topicRepository.deleteById(topicId);
     }
 

--- a/be/src/test/java/codesquad/bookkbookk/auth/repository/AuthorizationRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/auth/repository/AuthorizationRepositoryTest.java
@@ -1,0 +1,117 @@
+package codesquad.bookkbookk.auth.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import codesquad.bookkbookk.IntegrationTest;
+import codesquad.bookkbookk.domain.auth.repository.AuthorizationRepository;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.book.repository.BookRepository;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
+import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
+import codesquad.bookkbookk.domain.topic.repository.TopicRepository;
+import codesquad.bookkbookk.util.TestDataFactory;
+
+public class AuthorizationRepositoryTest extends IntegrationTest {
+
+    @Autowired
+    private AuthorizationRepository authorizationRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BookClubRepository bookClubRepository;
+    @Autowired
+    private BookClubMemberRepository bookClubMemberRepository;
+    @Autowired
+    private BookRepository bookRepository;
+    @Autowired
+    private ChapterRepository chapterRepository;
+    @Autowired
+    private TopicRepository topicRepository;
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("북클럽 멤버가 저장되었을 떄 멤버의 아이디와 북클럽 아이디로 조회에 성공한다.")
+    void existsBookClubMemberByBookClubIdAndMemberIdSucceed() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub();
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        // when
+        boolean result = authorizationRepository.existsBookClubMemberByMemberIdAndBookClubId(member.getId(),
+                bookClub.getId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("북클럽 멤버가 저장되지 않으면 멤버의 아이디와 북클럽 아이디로 조회했을 때 거짓이 나온다.")
+    void existsBookClubMemberByBookClubIdAndMemberIdFail() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub();
+        bookClubRepository.save(bookClub);
+
+        // when
+        boolean result = authorizationRepository.existsBookClubMemberByMemberIdAndBookClubId(member.getId(),
+                bookClub.getId());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("native query에 JOIN문 없이 '.'으로 하부항목을 검색하면 INNER JOIN이 붙는다.")
+    void addAutoInnerJoinToNativeQuery() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub();
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook1(bookClub);
+        bookRepository.save(book);
+
+        Chapter chapter = TestDataFactory.createChapter1(book);
+        chapterRepository.save(chapter);
+
+        Topic topic = TestDataFactory.createTopic1(chapter);
+        topicRepository.save(topic);
+
+        // when
+        boolean result = authorizationRepository.existsBookClubMemberByMemberIdAndTopicId(member.getId(),
+                topic.getId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/be/src/test/java/codesquad/bookkbookk/book/integration/BookTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/book/integration/BookTest.java
@@ -163,6 +163,9 @@ public class BookTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
 
@@ -200,6 +203,9 @@ public class BookTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember= new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);

--- a/be/src/test/java/codesquad/bookkbookk/bookclub/integration/BookClubTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/bookclub/integration/BookClubTest.java
@@ -97,6 +97,9 @@ public class BookClubTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book1 = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book1);
         Book book2 = TestDataFactory.createBook2(bookClub);
@@ -133,6 +136,9 @@ public class BookClubTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book1 = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book1);

--- a/be/src/test/java/codesquad/bookkbookk/bookmark/integration/BookmarkTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/bookmark/integration/BookmarkTest.java
@@ -29,7 +29,9 @@ import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.entity.BookmarkReaction;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.mapping.repository.BookmarkReactionRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
@@ -48,6 +50,8 @@ public class BookmarkTest extends IntegrationTest {
     MemberRepository memberRepository;
     @Autowired
     BookClubRepository bookClubRepository;
+    @Autowired
+    BookClubMemberRepository bookClubMemberRepository;
     @Autowired
     BookRepository bookRepository;
     @Autowired
@@ -73,6 +77,9 @@ public class BookmarkTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -288,6 +295,9 @@ public class BookmarkTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
 
@@ -326,6 +336,9 @@ public class BookmarkTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -458,6 +471,9 @@ public class BookmarkTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
 
@@ -503,6 +519,9 @@ public class BookmarkTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);

--- a/be/src/test/java/codesquad/bookkbookk/chapter/integration/ChapterTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/chapter/integration/ChapterTest.java
@@ -22,6 +22,8 @@ import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
@@ -39,6 +41,8 @@ public class ChapterTest extends IntegrationTest {
     MemberRepository memberRepository;
     @Autowired
     BookClubRepository bookClubRepository;
+    @Autowired
+    BookClubMemberRepository bookClubMemberRepository;
     @Autowired
     BookRepository bookRepository;
     @Autowired
@@ -60,6 +64,9 @@ public class ChapterTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -96,6 +103,9 @@ public class ChapterTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -135,6 +145,9 @@ public class ChapterTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
 
@@ -169,6 +182,9 @@ public class ChapterTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);

--- a/be/src/test/java/codesquad/bookkbookk/comment/integration/CommentTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/comment/integration/CommentTest.java
@@ -29,7 +29,9 @@ import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.entity.CommentReaction;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.mapping.repository.CommentReactionRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
@@ -48,6 +50,8 @@ public class CommentTest extends IntegrationTest {
     MemberRepository memberRepository;
     @Autowired
     BookClubRepository bookClubRepository;
+    @Autowired
+    BookClubMemberRepository bookClubMemberRepository;
     @Autowired
     BookRepository bookRepository;
     @Autowired
@@ -73,6 +77,9 @@ public class CommentTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -300,6 +307,9 @@ public class CommentTest extends IntegrationTest {
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
 
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
 
@@ -341,6 +351,9 @@ public class CommentTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -484,6 +497,9 @@ public class CommentTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);

--- a/be/src/test/java/codesquad/bookkbookk/topic/integration/TopicTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/topic/integration/TopicTest.java
@@ -16,6 +16,8 @@ import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 import codesquad.bookkbookk.domain.topic.data.dto.UpdateTopicTitleRequest;
@@ -46,6 +48,9 @@ public class TopicTest extends IntegrationTest {
     private BookClubRepository bookClubRepository;
 
     @Autowired
+    private BookClubMemberRepository bookClubMemberRepository;
+
+    @Autowired
     private JwtProvider jwtProvider;
 
     @DisplayName("성공적으로 토픽을 생성한다.")
@@ -58,6 +63,9 @@ public class TopicTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -97,6 +105,9 @@ public class TopicTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);
@@ -138,6 +149,9 @@ public class TopicTest extends IntegrationTest {
 
         BookClub bookClub = TestDataFactory.createBookClub();
         bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
 
         Book book = TestDataFactory.createBook1(bookClub);
         bookRepository.save(book);


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

인가 기능을 추가했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- JpaRepository에서 제공하는  exists 메서드를 사용하면 불필요한 join이 발생합니다.  또한 exists 메서드가 인가 작업에만 존재하기에 AuthorizationRepository를 생성하여 쿼리를 만들었습니다.
- Service 계층에서 memberId를 매개변수로 받지 않는 경우가 있습니다. 인가 기능을 사용하기 위해 Service의 parameter를 수정했습니다.
- reaction 삭제의 경우는 BookClub 멤버를 확인하지 않고 작성자임만을 확인합니다. 이는 작성시에 확인하기 때문입니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
