### PR TITLE
[BE] JwtFilter String 하드 코딩 삭제 && TokenError enum 생성

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/ErrorResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/ErrorResponse.java
@@ -28,7 +28,7 @@ public class ErrorResponse {
     }
 
     public static ErrorResponse from(AuthException exception) {
-        return new ErrorResponse(exception.getCode(), exception.getStatus(), exception.getMessage());
+        return new ErrorResponse(exception.getTokenError().getCode(), exception.getStatus(), exception.getMessage());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/AccessTokenIsInBlackListException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/AccessTokenIsInBlackListException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class AccessTokenIsInBlackListException extends AuthException{
 
     public AccessTokenIsInBlackListException() {
-        super(HttpStatus.UNAUTHORIZED, "Access Token이 Black List에 있습니다.", 4011);
+        super(HttpStatus.UNAUTHORIZED, "Access Token이 Black List에 있습니다.", TokenError.ACCESS_TOKEN);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/AuthException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/AuthException.java
@@ -3,17 +3,18 @@ package codesquad.bookkbookk.common.error.exception.auth;
 import org.springframework.http.HttpStatus;
 
 import codesquad.bookkbookk.common.error.exception.ApiException;
+import codesquad.bookkbookk.common.type.TokenError;
 
 import lombok.Getter;
 
 @Getter
 public class AuthException extends ApiException {
 
-    private final int code;
+    private final TokenError tokenError;
 
-    public AuthException(HttpStatus status, String message, int code) {
+    public AuthException(HttpStatus status, String message, TokenError tokenError) {
         super(status, message);
-        this.code = code;
+        this.tokenError = tokenError;
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/BearerPrefixNotIncludedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/BearerPrefixNotIncludedException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class BearerPrefixNotIncludedException extends AuthException {
 
     public BearerPrefixNotIncludedException() {
-        super(HttpStatus.BAD_REQUEST, "Bearer Prefix가 없습니다.", 4011);
+        super(HttpStatus.BAD_REQUEST, "Bearer Prefix가 없습니다.", TokenError.ACCESS_TOKEN);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/MalformedTokenException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/MalformedTokenException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class MalformedTokenException extends AuthException {
 
-    public MalformedTokenException(int code) {
-        super(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다.", code);
+    public MalformedTokenException(TokenError tokenError) {
+        super(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다.", tokenError);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/NoAuthorizationHeaderException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/NoAuthorizationHeaderException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class NoAuthorizationHeaderException extends AuthException {
 
     public NoAuthorizationHeaderException() {
-        super(HttpStatus.UNAUTHORIZED, "Authorization Header가 없습니다.", 4011);
+        super(HttpStatus.UNAUTHORIZED, "Authorization Header가 없습니다.", TokenError.ACCESS_TOKEN);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/TokenExpiredException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/TokenExpiredException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class TokenExpiredException extends AuthException {
 
-    public TokenExpiredException(int code) {
-        super(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다.", code);
+    public TokenExpiredException(TokenError tokenError) {
+        super(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다.", tokenError);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/TokenNotIncludedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/auth/TokenNotIncludedException.java
@@ -2,10 +2,12 @@ package codesquad.bookkbookk.common.error.exception.auth;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.TokenError;
+
 public class TokenNotIncludedException extends AuthException {
 
-    public TokenNotIncludedException(int code) {
-        super(HttpStatus.BAD_REQUEST, "토큰이 없습니다.", code);
+    public TokenNotIncludedException(TokenError tokenError) {
+        super(HttpStatus.BAD_REQUEST, "토큰이 없습니다.", tokenError);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/filter/JwtFilter.java
@@ -30,6 +30,7 @@ import codesquad.bookkbookk.common.error.exception.auth.TokenExpiredException;
 import codesquad.bookkbookk.common.error.exception.auth.TokenNotIncludedException;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
 import codesquad.bookkbookk.common.redis.RedisService;
+import codesquad.bookkbookk.common.type.TokenError;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -92,13 +93,13 @@ public class JwtFilter implements Filter {
         try {
             jwtProvider.validateToken(accessToken);
         } catch (IllegalArgumentException e) {
-            writeErrorResponse(new TokenNotIncludedException(4011), httpServletResponse);
+            writeErrorResponse(new TokenNotIncludedException(TokenError.ACCESS_TOKEN), httpServletResponse);
             return false;
         } catch (MalformedJwtException | SecurityException e) {
-            writeErrorResponse(new MalformedTokenException(4011), httpServletResponse);
+            writeErrorResponse(new MalformedTokenException(TokenError.ACCESS_TOKEN), httpServletResponse);
             return false;
         } catch (ExpiredJwtException e) {
-            writeErrorResponse(new TokenExpiredException(4011), httpServletResponse);
+            writeErrorResponse(new TokenExpiredException(TokenError.ACCESS_TOKEN), httpServletResponse);
             return false;
         }
         return true;
@@ -109,7 +110,7 @@ public class JwtFilter implements Filter {
         String refreshToken = null;
 
         if (cookies == null) {
-            writeErrorResponse(new TokenNotIncludedException(4012), httpServletResponse);
+            writeErrorResponse(new TokenNotIncludedException(TokenError.REFRESH_TOKEN), httpServletResponse);
             return false;
         }
         for (Cookie cookie : cookies) {
@@ -121,13 +122,13 @@ public class JwtFilter implements Filter {
         try {
             jwtProvider.validateToken(refreshToken);
         } catch (IllegalArgumentException e) {
-            writeErrorResponse(new TokenNotIncludedException(4012), httpServletResponse);
+            writeErrorResponse(new TokenNotIncludedException(TokenError.REFRESH_TOKEN), httpServletResponse);
             return false;
         } catch (MalformedJwtException | SecurityException e) {
-            writeErrorResponse(new MalformedTokenException(4012), httpServletResponse);
+            writeErrorResponse(new MalformedTokenException(TokenError.REFRESH_TOKEN), httpServletResponse);
             return false;
         } catch (ExpiredJwtException e) {
-            writeErrorResponse(new TokenExpiredException(4012), httpServletResponse);
+            writeErrorResponse(new TokenExpiredException(TokenError.REFRESH_TOKEN), httpServletResponse);
             return false;
         }
         return true;

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenArgumentResolver.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenArgumentResolver.java
@@ -13,6 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import codesquad.bookkbookk.common.error.exception.auth.TokenNotIncludedException;
+import codesquad.bookkbookk.common.type.TokenError;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class RefreshTokenArgumentResolver implements HandlerMethodArgumentResolv
                 return cookie.getValue();
             }
         }
-        throw new TokenNotIncludedException(4012);
+        throw new TokenNotIncludedException(TokenError.REFRESH_TOKEN);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/type/TokenError.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/type/TokenError.java
@@ -1,0 +1,15 @@
+package codesquad.bookkbookk.common.type;
+
+public enum TokenError {
+    ACCESS_TOKEN(4011), REFRESH_TOKEN(4012);
+
+    private final int code;
+
+    TokenError(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return this.code;
+    }
+}

--- a/be/src/test/java/codesquad/bookkbookk/filter/FilterTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/filter/FilterTest.java
@@ -20,6 +20,7 @@ import codesquad.bookkbookk.common.error.exception.auth.NoAuthorizationHeaderExc
 import codesquad.bookkbookk.common.error.exception.auth.TokenNotIncludedException;
 import codesquad.bookkbookk.common.jwt.JwtProvider;
 import codesquad.bookkbookk.common.redis.RedisService;
+import codesquad.bookkbookk.common.type.TokenError;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 import codesquad.bookkbookk.util.TestDataFactory;
@@ -59,7 +60,7 @@ class FilterTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertThat(response.statusCode()).isEqualTo(exception.getStatus().value());
-            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getTokenError().getCode());
             assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
                     .isEqualTo(exception.getMessage());
         });
@@ -70,7 +71,7 @@ class FilterTest extends IntegrationTest {
     @DisplayName("변형된 access token이 요청에 포함되면 에외가 한다.")
     void requestWithMalformedAccessToken() throws Exception {
         // given
-        MalformedTokenException exception = new MalformedTokenException(4011);
+        MalformedTokenException exception = new MalformedTokenException(TokenError.ACCESS_TOKEN);
         String accessToken = Jwts.builder()
                 .expiration(new Date(System.currentTimeMillis() + 30000))
                 .signWith(Keys.hmacShaKeyFor("thisiskeyfortestbookkbookk1234512356!!".getBytes()))
@@ -88,7 +89,7 @@ class FilterTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertThat(response.statusCode()).isEqualTo(exception.getStatus().value());
-            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getTokenError().getCode());
             assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
                     .isEqualTo(exception.getMessage());
         });
@@ -98,7 +99,7 @@ class FilterTest extends IntegrationTest {
     @DisplayName("refresh token이 필요한 요청에 토큰을 넣지 않으면 예외가 발생한다.")
     void requestWithMalformedToken() throws Exception {
         // given
-        TokenNotIncludedException exception = new TokenNotIncludedException(4012);
+        TokenNotIncludedException exception = new TokenNotIncludedException(TokenError.REFRESH_TOKEN);
 
         // when
         ExtractableResponse<Response> response = RestAssured
@@ -111,7 +112,7 @@ class FilterTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertThat(response.statusCode()).isEqualTo(exception.getStatus().value());
-            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getTokenError().getCode());
             assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
                     .isEqualTo(exception.getMessage());
         });
@@ -121,7 +122,7 @@ class FilterTest extends IntegrationTest {
     @DisplayName("변형된 refresh token이 요청에 포함되면 에외가 한다.")
     void requestWithMalformedRefreshToken() throws Exception {
         // given
-        MalformedTokenException exception = new MalformedTokenException(4012);
+        MalformedTokenException exception = new MalformedTokenException(TokenError.REFRESH_TOKEN);
         String token = Jwts.builder()
                 .signWith(Keys.hmacShaKeyFor("thisiskeyfortestbookkbookk1234512356!!".getBytes()))
                 .compact();
@@ -144,7 +145,7 @@ class FilterTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertThat(response.statusCode()).isEqualTo(exception.getStatus().value());
-            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getTokenError().getCode());
             assertThat(response.jsonPath().getObject("", ErrorResponse.class).getMessage())
                     .isEqualTo(exception.getMessage());
         });
@@ -174,7 +175,7 @@ class FilterTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertThat(response.statusCode()).isEqualTo(exception.getStatus().value());
-            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getCode());
+            assertThat(response.jsonPath().getInt("code")).isEqualTo(exception.getTokenError().getCode());
             assertThat(response.jsonPath().getString("message")).isEqualTo(exception.getMessage());
         });
     }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- JwtFilter에 있는 하드코딩 되어있는 String 중 일부를 의미 있는 코드로 변경했습니다.
- 4012, 4011로Access Token에서 발생하는 오류와 Refrest Token에서 발생하는 오류를 구분했는데 좀 더 의미있는 코드가 되기 위해 숫자 대신 enum을 도입했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
