### PR TITLE
[BE] Refresh Token에 UUID 필드 추가

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/config/WebConfig.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/config/WebConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import codesquad.bookkbookk.common.resolver.AccessTokenArgumentResolver;
 import codesquad.bookkbookk.common.resolver.JwtArgumentResolver;
-import codesquad.bookkbookk.common.resolver.RefreshTokenArgumentResolver;
+import codesquad.bookkbookk.common.resolver.RefreshTokenUuidArgumentResolver;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -17,14 +17,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Autowired
     private JwtArgumentResolver jwtArgumentResolver;
     @Autowired
-    private RefreshTokenArgumentResolver refreshTokenArgumentResolver;
+    private RefreshTokenUuidArgumentResolver refreshTokenUuidArgumentResolver;
     @Autowired
     private AccessTokenArgumentResolver accessTokenArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(jwtArgumentResolver);
-        resolvers.add(refreshTokenArgumentResolver);
+        resolvers.add(refreshTokenUuidArgumentResolver);
         resolvers.add(accessTokenArgumentResolver);
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
@@ -63,6 +63,15 @@ public class JwtProvider {
                 .get("memberId", Long.class);
     }
 
+    public String extractUuid(String refreshToken) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(refreshToken)
+                .getPayload()
+                .get("uuid", String.class);
+    }
+
     public void validateToken(String token) {
         Jwts.parser()
                 .verifyWith(key)

--- a/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/jwt/JwtProvider.java
@@ -1,6 +1,5 @@
 package codesquad.bookkbookk.common.jwt;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -28,10 +27,10 @@ public class JwtProvider {
         this.key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
     }
 
-    public Jwt createJwt(Long memberId) {
+    public Jwt createJwt(Long memberId, String uuid) {
         return Jwt.builder()
                 .accessToken(createAccessToken(memberId))
-                .refreshToken(createRefreshToken())
+                .refreshToken(createRefreshToken(uuid))
                 .build();
     }
 
@@ -42,9 +41,9 @@ public class JwtProvider {
         return createToken(claims, expiration);
     }
 
-    public String createRefreshToken() {
+    public String createRefreshToken(String uuid) {
         Date expiration = new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpiration());
-        Map<String, Object> claims = Collections.emptyMap();
+        Map<String, Object> claims = Map.of("uuid", uuid);
 
         return createToken(claims, expiration);
     }

--- a/be/src/main/java/codesquad/bookkbookk/common/redis/RedisService.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/redis/RedisService.java
@@ -39,8 +39,8 @@ public class RedisService {
         return redisTemplate.hasKey(key);
     }
 
-    public void saveRefreshToken(String refreshToken, Long memberId) {
-        String key = REFRESH_TOKEN_PREFIX + refreshToken;
+    public void saveRefreshTokenUuid(String refreshTokenUuid, Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + refreshTokenUuid;
 
         redisTemplate.opsForValue().set(key, String.valueOf(memberId), jwtProperties.getRefreshTokenExpiration(),
                 TimeUnit.MILLISECONDS);

--- a/be/src/main/java/codesquad/bookkbookk/common/redis/RedisService.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/redis/RedisService.java
@@ -46,8 +46,8 @@ public class RedisService {
                 TimeUnit.MILLISECONDS);
     }
 
-    public Long getMemberIdByRefreshToken(String refreshToken) {
-        String key = REFRESH_TOKEN_PREFIX + refreshToken;
+    public Long getMemberIdByUuid(String uuid) {
+        String key = REFRESH_TOKEN_PREFIX + uuid;
         Object result = redisTemplate.opsForValue().get(key);
 
         if (result == null) return null;

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenUuid.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenUuid.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface RefreshToken {
+public @interface RefreshTokenUuid {
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenUuidArgumentResolver.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/resolver/RefreshTokenUuidArgumentResolver.java
@@ -13,6 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import codesquad.bookkbookk.common.error.exception.auth.TokenNotIncludedException;
+import codesquad.bookkbookk.common.jwt.JwtProvider;
 import codesquad.bookkbookk.common.type.TokenError;
 
 import lombok.NonNull;
@@ -20,11 +21,13 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Component
-public class RefreshTokenArgumentResolver implements HandlerMethodArgumentResolver {
+public class RefreshTokenUuidArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(RefreshToken.class) && parameter.getParameterType().equals(String.class);
+        return parameter.hasParameterAnnotation(RefreshTokenUuid.class) && parameter.getParameterType().equals(String.class);
     }
 
     @Override
@@ -34,7 +37,7 @@ public class RefreshTokenArgumentResolver implements HandlerMethodArgumentResolv
 
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals("refreshToken")) {
-                return cookie.getValue();
+                return jwtProvider.extractUuid(cookie.getValue());
             }
         }
         throw new TokenNotIncludedException(TokenError.REFRESH_TOKEN);

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.common.jwt.JwtProperties;
 import codesquad.bookkbookk.common.resolver.AccessToken;
-import codesquad.bookkbookk.common.resolver.RefreshToken;
+import codesquad.bookkbookk.common.resolver.RefreshTokenUuid;
 import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
 import codesquad.bookkbookk.domain.auth.data.dto.ReissueResponse;
@@ -48,15 +48,15 @@ public class AuthController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<ReissueResponse> reissueAccessToken(@RefreshToken String refreshToken) {
-        ReissueResponse response = authenticationService.reissueAccessToken(refreshToken);
+    public ResponseEntity<ReissueResponse> reissueAccessToken(@RefreshTokenUuid String uuid) {
+        ReissueResponse response = authenticationService.reissueAccessToken(uuid);
 
         return ResponseEntity.ok()
                 .body(response);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AccessToken String accessToken, @RefreshToken String refreshToken) {
+    public ResponseEntity<Void> logout(@AccessToken String accessToken, @RefreshTokenUuid String refreshToken) {
         authenticationService.logout(accessToken, refreshToken);
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", "")

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.auth.service;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
@@ -45,7 +46,8 @@ public class AuthenticationService {
 
         boolean doesMemberExist = memberRepository.existsByEmail(loginRequest.getEmail());
         Member loginMember = getLoginMember(loginRequest, doesMemberExist);
-        Jwt jwt = jwtProvider.createJwt(loginMember.getId());
+        UUID refreshTokenUuid = UUID.randomUUID();
+        Jwt jwt = jwtProvider.createJwt(loginMember.getId(), refreshTokenUuid.toString());
 
         redisService.saveRefreshToken(jwt.getRefreshToken(), loginMember.getId());
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
@@ -46,10 +46,10 @@ public class AuthenticationService {
 
         boolean doesMemberExist = memberRepository.existsByEmail(loginRequest.getEmail());
         Member loginMember = getLoginMember(loginRequest, doesMemberExist);
-        UUID refreshTokenUuid = UUID.randomUUID();
-        Jwt jwt = jwtProvider.createJwt(loginMember.getId(), refreshTokenUuid.toString());
+        String refreshTokenUuid = UUID.randomUUID().toString();
+        Jwt jwt = jwtProvider.createJwt(loginMember.getId(), refreshTokenUuid);
 
-        redisService.saveRefreshToken(jwt.getRefreshToken(), loginMember.getId());
+        redisService.saveRefreshTokenUuid(refreshTokenUuid, loginMember.getId());
 
         return LoginResponse.of(jwt, doesMemberExist);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthenticationService.java
@@ -55,8 +55,8 @@ public class AuthenticationService {
     }
 
     @Transactional(readOnly = true)
-    public ReissueResponse reissueAccessToken(String refreshToken) {
-        Long memberId = redisService.getMemberIdByRefreshToken(refreshToken);
+    public ReissueResponse reissueAccessToken(String uuid) {
+        Long memberId = redisService.getMemberIdByUuid(uuid);
         if (memberId == null) throw new RefreshTokenNotSavedException();
 
         String accessToken = jwtProvider.createAccessToken(memberId);

--- a/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
@@ -45,7 +45,7 @@ public class AuthTest extends IntegrationTest {
         memberRepository.save(member);
 
         String accessToken = jwtProvider.createAccessToken(member.getId());
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
         redisService.saveRefreshToken(refreshToken, member.getId());
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
@@ -81,7 +81,7 @@ public class AuthTest extends IntegrationTest {
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
 
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .domain("localhost")
@@ -115,7 +115,7 @@ public class AuthTest extends IntegrationTest {
         memberRepository.save(member);
         String accessToken = jwtProvider.createAccessToken(member.getId());
 
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
         redisService.saveRefreshToken(refreshToken, member.getId());
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)

--- a/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/auth/integration/AuthTest.java
@@ -2,6 +2,8 @@ package codesquad.bookkbookk.auth.integration;
 
 import static java.lang.Thread.*;
 
+import java.util.UUID;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,9 +46,10 @@ public class AuthTest extends IntegrationTest {
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
 
+        String uuid = UUID.randomUUID().toString();
         String accessToken = jwtProvider.createAccessToken(member.getId());
-        String refreshToken = jwtProvider.createRefreshToken("uuid");
-        redisService.saveRefreshToken(refreshToken, member.getId());
+        String refreshToken = jwtProvider.createRefreshToken(uuid);
+        redisService.saveRefreshTokenUuid(uuid, member.getId());
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .domain("localhost")
@@ -115,8 +118,9 @@ public class AuthTest extends IntegrationTest {
         memberRepository.save(member);
         String accessToken = jwtProvider.createAccessToken(member.getId());
 
-        String refreshToken = jwtProvider.createRefreshToken("uuid");
-        redisService.saveRefreshToken(refreshToken, member.getId());
+        String uuid = UUID.randomUUID().toString();
+        String refreshToken = jwtProvider.createRefreshToken(uuid);
+        redisService.saveRefreshTokenUuid(uuid, member.getId());
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .domain("localhost")
@@ -137,9 +141,9 @@ public class AuthTest extends IntegrationTest {
         // then
         SoftAssertions.assertSoftly(assertions -> {
             assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-            assertions.assertThatThrownBy(() -> authenticationService.reissueAccessToken(refreshToken))
+            assertions.assertThatThrownBy(() -> authenticationService.reissueAccessToken(uuid))
                     .isInstanceOf(RefreshTokenNotSavedException.class);
-            assertions.assertThat(redisService.getMemberIdByRefreshToken(refreshToken)).isNull();
+            assertions.assertThat(redisService.getMemberIdByUuid(uuid)).isNull();
             assertions.assertThat(redisService.isAccessTokenPresent(accessToken)).isTrue();
         });
     }

--- a/be/src/test/java/codesquad/bookkbookk/redis/RedisServiceTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/redis/RedisServiceTest.java
@@ -79,7 +79,7 @@ public class RedisServiceTest extends IntegrationTest {
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
 
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
 
         // when
         redisService.saveRefreshToken(refreshToken, member.getId());
@@ -95,7 +95,7 @@ public class RedisServiceTest extends IntegrationTest {
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
 
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
 
         // when
         redisService.saveRefreshToken(refreshToken, member.getId());
@@ -112,7 +112,7 @@ public class RedisServiceTest extends IntegrationTest {
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
 
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken("uuid");
         redisService.saveRefreshToken(refreshToken, member.getId());
 
         // when

--- a/be/src/test/java/codesquad/bookkbookk/redis/RedisServiceTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/redis/RedisServiceTest.java
@@ -82,10 +82,10 @@ public class RedisServiceTest extends IntegrationTest {
         String refreshToken = jwtProvider.createRefreshToken("uuid");
 
         // when
-        redisService.saveRefreshToken(refreshToken, member.getId());
+        redisService.saveRefreshTokenUuid(refreshToken, member.getId());
 
         // then
-        assertThat(redisService.getMemberIdByRefreshToken(refreshToken)).isEqualTo(member.getId());
+        assertThat(redisService.getMemberIdByUuid(refreshToken)).isEqualTo(member.getId());
     }
 
     @Test
@@ -98,11 +98,11 @@ public class RedisServiceTest extends IntegrationTest {
         String refreshToken = jwtProvider.createRefreshToken("uuid");
 
         // when
-        redisService.saveRefreshToken(refreshToken, member.getId());
+        redisService.saveRefreshTokenUuid(refreshToken, member.getId());
         Thread.sleep(jwtProperties.getRefreshTokenExpiration() + 1000);
 
         // then
-        assertThat(redisService.getMemberIdByRefreshToken(refreshToken)).isNull();
+        assertThat(redisService.getMemberIdByUuid(refreshToken)).isNull();
     }
 
     @Test
@@ -113,13 +113,13 @@ public class RedisServiceTest extends IntegrationTest {
         memberRepository.save(member);
 
         String refreshToken = jwtProvider.createRefreshToken("uuid");
-        redisService.saveRefreshToken(refreshToken, member.getId());
+        redisService.saveRefreshTokenUuid(refreshToken, member.getId());
 
         // when
         redisService.deleteRefreshToken(refreshToken);
 
         // then
-        assertThat(redisService.getMemberIdByRefreshToken(refreshToken)).isNull();
+        assertThat(redisService.getMemberIdByUuid(refreshToken)).isNull();
     }
 
     @Test


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- Refresh Token의 Payload에 uuid를 추가하여 유일성을 보장했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 유일성을 보장하기 위해서 uuid를 고민했습니다. 이 과정에서 Refresh Token이 굳이 JWT 형식이여야 하나 고민했습니다만, 그냥 uuid로 통신하게 되면 DB에 부담될 수 있어서 JWT의 Payload에 uuid를 넣었습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
