### PR TITLE
[BE] 프로필에 따른 Http Cookie의 옵션 다양화

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package codesquad.bookkbookk.domain.auth.controller;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,7 @@ import codesquad.bookkbookk.common.resolver.RefreshTokenUuid;
 import codesquad.bookkbookk.domain.auth.data.dto.AuthCode;
 import codesquad.bookkbookk.domain.auth.data.dto.LoginResponse;
 import codesquad.bookkbookk.domain.auth.data.dto.ReissueResponse;
+import codesquad.bookkbookk.domain.auth.data.property.CookieProperty;
 import codesquad.bookkbookk.domain.auth.service.AuthenticationService;
 
 import lombok.RequiredArgsConstructor;
@@ -25,20 +25,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-
     private final AuthenticationService authenticationService;
     private final JwtProperties jwtProperties;
-
-    @Value("${cookie.domain}")
-    private String cookieDomain;
+    private final CookieProperty cookieProperty;
 
     @PostMapping("/login/{providerName}")
     public ResponseEntity<LoginResponse> login(@RequestBody AuthCode authCode, @PathVariable String providerName) {
         LoginResponse loginResponse = authenticationService.login(authCode, providerName);
         ResponseCookie refreshToken = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken())
                 .httpOnly(true)
+                .secure(cookieProperty.isSecure())
                 .maxAge(jwtProperties.getRefreshTokenExpiration() / 1000)
-                .domain(cookieDomain)
+                .domain(cookieProperty.getDomain())
                 .path("/api")
                 .build();
 
@@ -61,8 +59,9 @@ public class AuthController {
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
+                .secure(cookieProperty.isSecure())
                 .maxAge(0)
-                .domain(cookieDomain)
+                .domain(cookieProperty.getDomain())
                 .path("/api")
                 .build();
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/property/CookieProperty.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/property/CookieProperty.java
@@ -1,0 +1,17 @@
+package codesquad.bookkbookk.domain.auth.data.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@ConfigurationProperties(prefix = "cookie")
+@ConstructorBinding
+public class CookieProperty {
+
+    private final String domain;
+    private final boolean secure;
+}


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

Http Cookie의 옵션을 프로필에 따라 다르게 설정할 수 있게 변경합니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

개발 서버와 운영 서버의 secure 옵션이 달라야 한다고 생각해서 변경했습니다.

개발 서버의 경우 도메인이 없어 http로 통신하는데 반해 운영 서버는 도메인을 구입해서 https 프로토콜을 사용합니다.

코드가 `secure` 옵션을 사용하지 않도록 일원화 되어있는데, 개발 서버, 로컬, 운영 서버를 구분해서 운영 서버에서는 `secure` 옵션을 사용해 보안을 강화했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
