### PR TITLE
[FE] BookDetail에서 ChapterItem tree 랜더링 오류  해결

### DIFF
--- a/fe/src/components/BookDetail/BookChapterListPanel/ChapterItem.tsx
+++ b/fe/src/components/BookDetail/BookChapterListPanel/ChapterItem.tsx
@@ -10,6 +10,7 @@ import { TopicItem } from "./TopicItem";
 
 export function ChapterItem({ chapter }: { chapter: ChapterListItem }) {
   const { chapterId, title } = chapter;
+  const chapterPrefix = "chapter_";
   const navigate = useNavigate();
   const {
     state: { book },
@@ -40,7 +41,7 @@ export function ChapterItem({ chapter }: { chapter: ChapterListItem }) {
       </Stack>
       <TreeItem
         sx={{ width: "90%" }}
-        nodeId={chapterId + ""}
+        nodeId={chapterPrefix + chapterId}
         label={<Typography variant="h5">{title}</Typography>}>
         <Stack gap={1} paddingY={1}>
           {chapter.topics.map((topic) => (

--- a/fe/src/components/BookDetail/BookChapterListPanel/TopicItem.tsx
+++ b/fe/src/components/BookDetail/BookChapterListPanel/TopicItem.tsx
@@ -14,10 +14,11 @@ export function TopicItem({
   onClick: (topic: Pick<TopicItemInfo, "topicId" | "title">) => void;
 }) {
   const { topicId, title, recentBookmark } = topic;
+  const topicPrefix = "topic_";
 
   return (
     <TreeItem
-      nodeId={topicId + ""}
+      nodeId={topicPrefix + topicId}
       icon={<LabelImportantIcon />}
       onClick={() => onClick({ topicId, title })}
       label={


### PR DESCRIPTION
- 이슈: #214

- nodeId에 prefix를 붙여서 유일성을 보장했습니다.

