### PR TITLE
[BE] 레포지토리 코드 개선

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.book.data.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -19,6 +20,7 @@ import codesquad.bookkbookk.common.error.exception.MalformedIsbnException;
 import codesquad.bookkbookk.common.type.Status;
 import codesquad.bookkbookk.domain.book.data.dto.UpdateBookStatusRequest;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 
 import lombok.AccessLevel;
@@ -62,8 +64,11 @@ public class Book {
     @Column(nullable = false)
     private String category;
 
-    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Gathering> gatherings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Chapter> chapters = new ArrayList<>();
 
     @Builder
     private Book(String isbn, BookClub bookClub, String title, String cover, String author, String category) {
@@ -74,6 +79,13 @@ public class Book {
         this.author = author;
         this.category = category;
         this.status = Status.BEFORE_READING;
+    }
+    public boolean addGathering(Gathering gathering) {
+        return this.getGatherings().add(gathering);
+    }
+
+    public boolean addChapter(Chapter chapter) {
+        return this.getChapters().add(chapter);
     }
 
     private String validateAndFormatISBN(String isbn) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -22,6 +22,7 @@ import codesquad.bookkbookk.domain.book.data.dto.UpdateBookStatusRequest;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
+import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -72,6 +73,9 @@ public class Book {
 
     @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Chapter> chapters = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberBook> bookMembers = new ArrayList<>();
 
     @Builder
     private Book(String isbn, BookClub bookClub, String title, String cover, String author, String category) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -45,6 +45,9 @@ public class Book {
     @JoinColumn(name = "book_club_id")
     private BookClub bookClub;
 
+    @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
+    private Long bookClubId;
+
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private Status status;
@@ -74,6 +77,7 @@ public class Book {
     private Book(String isbn, BookClub bookClub, String title, String cover, String author, String category) {
         this.isbn = validateAndFormatISBN(isbn);
         this.bookClub = bookClub;
+        if (bookClub != null) this.bookClubId = bookClub.getId();
         this.title = title;
         this.cover = cover;
         this.author = author;

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -40,6 +40,7 @@ public class Book {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/data/entity/Book.java
@@ -42,8 +42,8 @@ public class Book {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_club_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_club_id", nullable = false)
     private BookClub bookClub;
 
     @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
@@ -88,12 +88,17 @@ public class Book {
         this.category = category;
         this.status = Status.BEFORE_READING;
     }
+
     public boolean addGathering(Gathering gathering) {
         return this.getGatherings().add(gathering);
     }
 
     public boolean addChapter(Chapter chapter) {
         return this.getChapters().add(chapter);
+    }
+
+    public boolean addMember(MemberBook bookMember) {
+        return this.getBookMembers().add(bookMember);
     }
 
     private String validateAndFormatISBN(String isbn) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookCustomRepository.java
@@ -1,0 +1,15 @@
+package codesquad.bookkbookk.domain.book.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+
+public interface BookCustomRepository {
+
+    Page<Book> findPageByMemberId(Long memberId, Pageable pageable);
+
+    Slice<Book> findSliceByBookClubId(Long bookClubId, Pageable pageable);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookCustomRepositoryImpl.java
@@ -1,0 +1,69 @@
+package codesquad.bookkbookk.domain.book.repository;
+
+import static codesquad.bookkbookk.domain.book.data.entity.QBook.*;
+import static codesquad.bookkbookk.domain.mapping.entity.QMemberBook.*;
+import static codesquad.bookkbookk.domain.member.data.entity.QMember.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BookCustomRepositoryImpl implements BookCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Book> findPageByMemberId(Long memberId, Pageable pageable) {
+        List<Book> books = jpaQueryFactory
+                .selectFrom(book)
+                .innerJoin(book.bookMembers, memberBook).fetchJoin()
+                .innerJoin(memberBook.member, member).fetchJoin()
+                .innerJoin(book.bookClub).fetchJoin()
+                .where(member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .selectFrom(book)
+                .innerJoin(book.bookMembers, memberBook)
+                .innerJoin(memberBook.member, member)
+                .innerJoin(book.bookClub)
+                .where(member.id.eq(memberId))
+                .fetchCount();
+
+        return new PageImpl<>(books, pageable, total);
+    }
+
+    @Override
+    public Slice<Book> findSliceByBookClubId(Long bookClubId, Pageable pageable) {
+        List<Book> books = jpaQueryFactory
+                .selectFrom(book)
+                .where(book.bookClub.id.eq(bookClubId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = books.size() > pageable.getPageSize();
+
+        if (hasNext) {
+            books.remove(books.size() - 1);
+        }
+
+        return new SliceImpl<>(books, pageable, hasNext);
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/repository/BookRepository.java
@@ -1,5 +1,7 @@
 package codesquad.bookkbookk.domain.book.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -8,13 +10,16 @@ import org.springframework.data.jpa.repository.Query;
 
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 
-public interface BookRepository extends JpaRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Long>, BookCustomRepository {
 
     @Query("SELECT book FROM Book book " +
             "JOIN MemberBook AS memberBook " +
             "ON book.id = memberBook.book.id " +
             "WHERE memberBook.member.id = :memberId")
     Page<Book> findBooksByMemberId(Long memberId, Pageable pageable);
+
     Slice<Book> findBooksByBookClubId(Long bookClubId, Pageable pageable);
+
+    Optional<Book> findByBookClubId(Long bookClubId);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -62,7 +62,7 @@ public class BookService {
     }
 
     public ReadBookResponse readBooks(Long memberId, Pageable pageable) {
-        Page<Book> books = bookRepository.findBooksByMemberId(memberId, pageable);
+        Page<Book> books = bookRepository.findPageByMemberId(memberId, pageable);
 
         return ReadBookResponse.from(books);
     }
@@ -70,7 +70,7 @@ public class BookService {
     public ReadBookClubBookResponse readBookClubBooks(Long memberId, Long bookClubId, Pageable pageable) {
         authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 
-        Slice<Book> books = bookRepository.findBooksByBookClubId(bookClubId, pageable);
+        Slice<Book> books = bookRepository.findSliceByBookClubId(bookClubId, pageable);
         return ReadBookClubBookResponse.from(books);
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -57,7 +57,6 @@ public class BookService {
         member.addBook(book);
 
         bookRepository.save(book);
-        memberRepository.save(member);
 
         return new CreateBookResponse(book.getId());
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -20,7 +20,6 @@ import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
-import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
 import codesquad.bookkbookk.domain.mapping.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
@@ -38,11 +37,13 @@ public class BookService {
     private final MemberRepository memberRepository;
     private final MemberBookRepository memberBookRepository;
 
+    @Transactional
     public CreateBookResponse createBook(Long memberId, CreateBookRequest request) {
         authorizationService.authorizeBookClubMembershipByBookClubId(memberId, request.getBookClubId());
 
         BookClub bookclub = bookClubRepository.findById(request.getBookClubId())
                 .orElseThrow(BookClubNotFoundException::new);
+
         Book book = Book.builder()
                 .isbn(request.getIsbn())
                 .bookClub(bookclub)
@@ -52,21 +53,23 @@ public class BookService {
                 .category(request.getCategory())
                 .build();
 
-        bookRepository.save(book);
-
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        MemberBook memberBook = new MemberBook(member, book);
-        memberBookRepository.save(memberBook);
+        member.addBook(book);
+
+        bookRepository.save(book);
+        memberRepository.save(member);
 
         return new CreateBookResponse(book.getId());
     }
 
+    @Transactional(readOnly = true)
     public ReadBookResponse readBooks(Long memberId, Pageable pageable) {
         Page<Book> books = bookRepository.findPageByMemberId(memberId, pageable);
 
         return ReadBookResponse.from(books);
     }
 
+    @Transactional(readOnly = true)
     public ReadBookClubBookResponse readBookClubBooks(Long memberId, Long bookClubId, Pageable pageable) {
         authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/JoinBookClubResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/JoinBookClubResponse.java
@@ -1,6 +1,6 @@
 package codesquad.bookkbookk.domain.bookclub.data.dto;
 
-import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +11,8 @@ public class JoinBookClubResponse {
 
     private final Long bookClubId;
 
-    public static JoinBookClubResponse from(BookClubMember bookClubMember) {
-        return new JoinBookClubResponse(bookClubMember.getBookClub().getId());
+    public static JoinBookClubResponse from(BookClub bookClub) {
+        return new JoinBookClubResponse(bookClub.getId());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -4,10 +4,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -56,9 +58,10 @@ public class BookClub {
     @Column(columnDefinition = "TIMESTAMP")
     private Instant upcomingGatheringTime;
 
-    @OneToMany(mappedBy = "bookClub")
+    @OneToMany(mappedBy = "bookClub", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookClubMember> bookClubMembers = new ArrayList<>();
-    @OneToMany(mappedBy = "bookClub")
+
+    @OneToMany(mappedBy = "bookClub", fetch = FetchType.LAZY)
     private List<Book> books = new ArrayList<>();
 
     @Builder
@@ -67,6 +70,14 @@ public class BookClub {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.status = BookClubStatus.OPEN;
+    }
+
+    public boolean addMember(BookClubMember bookClubMember) {
+        return this.bookClubMembers.add(bookClubMember);
+    }
+
+    public boolean addBook(Book book) {
+        return this.books.add(book);
     }
 
     public void updateUpcomingGatheringDate(Instant gatheringTime) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -33,6 +33,7 @@ public class BookClub {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_club_id", nullable = false)
     private Long id;
 
     @Column(nullable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepository.java
@@ -1,0 +1,16 @@
+package codesquad.bookkbookk.domain.bookclub.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+
+public interface BookClubCustomRepository {
+
+    List<BookClub> findAllByMemberIdAndStatus(Long memberId, BookClubStatus bookClubStatus);
+
+    Optional<BookClub> findDetailById(Long bookClubId);
+
+}
+

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepository.java
@@ -12,5 +12,7 @@ public interface BookClubCustomRepository {
 
     Optional<BookClub> findDetailById(Long bookClubId);
 
+    Optional<BookClub> findByIdWithBooks(Long bookClubId);
+
 }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepositoryImpl.java
@@ -1,0 +1,60 @@
+package codesquad.bookkbookk.domain.bookclub.repository;
+
+import static codesquad.bookkbookk.domain.bookclub.data.entity.QBookClub.*;
+import static codesquad.bookkbookk.domain.mapping.entity.QBookClubMember.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.Hibernate;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BookClubCustomRepositoryImpl implements BookClubCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<BookClub> findAllByMemberIdAndStatus(Long memberId, BookClubStatus bookClubStatus) {
+        List<BookClub> bookClubs = jpaQueryFactory
+                .selectFrom(bookClub)
+                .innerJoin(bookClub.bookClubMembers, bookClubMember)
+                .where(bookClubMember.member.id.eq(memberId),
+                        createBookClubStatusCondition(bookClubStatus))
+                .fetch();
+        bookClubs.stream().map(BookClub::getBooks).forEach(Hibernate::initialize);
+        bookClubs.stream().map(BookClub::getBookClubMembers).forEach(Hibernate::initialize);
+
+        return bookClubs;
+    }
+
+    @Override
+    public Optional<BookClub> findDetailById(Long bookClubId) {
+        Optional<BookClub> optional = Optional.ofNullable(jpaQueryFactory
+                .selectFrom(bookClub)
+                .where(bookClub.id.eq(bookClubId))
+                .fetchOne());
+        if (optional.isPresent()) {
+            optional.get().getBooks().forEach(Hibernate::initialize);
+            optional.get().getBookClubMembers().forEach(Hibernate::initialize);
+        }
+        return optional;
+    }
+
+    private BooleanExpression createBookClubStatusCondition(BookClubStatus bookClubStatus) {
+        if (bookClubStatus == null) {
+            return null;
+        }
+        return bookClub.status.eq(bookClubStatus);
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubCustomRepositoryImpl.java
@@ -50,6 +50,15 @@ public class BookClubCustomRepositoryImpl implements BookClubCustomRepository {
         return optional;
     }
 
+    @Override
+    public Optional<BookClub> findByIdWithBooks(Long bookClubId) {
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(bookClub)
+                .leftJoin(bookClub.books).fetchJoin()
+                .where(bookClub.id.eq(bookClubId))
+                .fetchOne());
+    }
+
     private BooleanExpression createBookClubStatusCondition(BookClubStatus bookClubStatus) {
         if (bookClubStatus == null) {
             return null;

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/repository/BookClubRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 
-public interface BookClubRepository extends JpaRepository<BookClub, Long> {
+public interface BookClubRepository extends JpaRepository<BookClub, Long>, BookClubCustomRepository {
 
     @Query("SELECT bookclub FROM BookClub bookclub " +
             "JOIN BookClubMember AS bookClubMember " +

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -79,20 +79,16 @@ public class BookClubService {
     }
 
     public List<ReadBookClubDetailResponse> readBookClubs(Long memberId, String statusName) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-
+        BookClubStatus status;
         if (statusName.equals(STATUS_ALL)) {
-            return  member.getBookClubs().stream()
-                    .map(bookClub -> bookClub.getStatus().from(bookClub))
-                    .collect(Collectors.toUnmodifiableList());
+            status = null;
+        } else {
+            status = BookClubStatus.of(statusName);
         }
 
-        BookClubStatus status = BookClubStatus.of(statusName);
-        List<BookClub> filteredBookClubs = member.getBookClubs().stream()
-                .filter(bookClub -> bookClub.getStatus().equals(status))
+        return bookClubRepository.findAllByMemberIdAndStatus(memberId, status).stream()
+                .map(bookClub -> bookClub.getStatus().from(bookClub))
                 .collect(Collectors.toUnmodifiableList());
-
-        return status.from(filteredBookClubs);
     }
 
     public InvitationUrlResponse createInvitationUrl(Long memberId, CreateInvitationUrlRequest request) {
@@ -126,7 +122,7 @@ public class BookClubService {
     public ReadBookClubDetailResponse readBookClubDetail(Long memberId, Long bookClubId) {
         authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 
-        BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
+        BookClub bookClub = bookClubRepository.findDetailById(bookClubId).orElseThrow(BookClubNotFoundException::new);
 
         return bookClub.getStatus().from(bookClub);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -113,10 +113,7 @@ public class BookClubService {
         authorizationService.authorizeBookClubJoin(memberId, bookClub.getId());
 
         bookClub.addMember(new BookClubMember(bookClub, member));
-        bookClubRepository.save(bookClub);
-
         bookClub.getBooks().forEach(member::addBook);
-        memberRepository.save(member);
 
         return JoinBookClubResponse.from(bookClub);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -25,7 +25,6 @@ import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
-import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.mapping.repository.MemberBookRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
@@ -116,10 +115,7 @@ public class BookClubService {
         bookClub.addMember(new BookClubMember(bookClub, member));
         bookClubRepository.save(bookClub);
 
-        bookClub.getBooks().forEach(book -> {
-            MemberBook memberBook = new MemberBook(member, book);
-            member.addBook(memberBook);
-        });
+        bookClub.getBooks().forEach(member::addBook);
         memberRepository.save(member);
 
         return JoinBookClubResponse.from(bookClub);

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
@@ -38,15 +38,15 @@ public class Bookmark {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "writer_id", nullable = false)
     private Member writer;
 
     @Column(name = "writer_id", nullable = false, insertable = false, updatable = false)
     private Long writerId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "topic_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "topic_id", nullable = false)
     private Topic topic;
 
     @Column(name = "topic_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
@@ -42,9 +42,15 @@ public class Bookmark {
     @JoinColumn(name = "writer_id")
     private Member writer;
 
+    @Column(name = "writer_id", nullable = false, insertable = false, updatable = false)
+    private Long writerId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id")
     private Topic topic;
+
+    @Column(name = "topic_id", nullable = false, insertable = false, updatable = false)
+    private Long topicId;
 
     @Column(nullable = false)
     private Integer page;
@@ -69,7 +75,9 @@ public class Bookmark {
     @Builder
     private Bookmark(Member writer, Topic topic, Integer page, String contents) {
         this.writer = writer;
+        if (writer != null) this.writerId = writer.getId();
         this.topic = topic;
+        if (topic != null) this.topicId = topic.getId();
         this.page = page;
         this.contents = contents;
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
@@ -36,6 +36,7 @@ public class Bookmark {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/entity/Bookmark.java
@@ -3,8 +3,8 @@ package codesquad.bookkbookk.domain.bookmark.data.entity;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -18,7 +18,6 @@ import javax.persistence.OneToMany;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import codesquad.bookkbookk.common.type.Reaction;
 import codesquad.bookkbookk.domain.bookmark.data.dto.UpdateBookmarkRequest;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 import codesquad.bookkbookk.domain.mapping.entity.BookmarkReaction;
@@ -61,9 +60,10 @@ public class Bookmark {
     @Column(columnDefinition = "TIMESTAMP", nullable = false)
     private Instant updatedTime;
 
-    @OneToMany(mappedBy = "bookmark")
+    @OneToMany(mappedBy = "bookmark", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookmarkReaction> bookmarkReactions = new ArrayList<>();
-    @OneToMany(mappedBy = "bookmark")
+
+    @OneToMany(mappedBy = "bookmark", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
@@ -74,15 +74,17 @@ public class Bookmark {
         this.contents = contents;
     }
 
+    public boolean addComment(Comment comment) {
+        return this.comments.add(comment);
+    }
+
+    public boolean addReaction(BookmarkReaction bookmarkReaction) {
+        return this.bookmarkReactions.add(bookmarkReaction);
+    }
+
     public void updateBookmark(UpdateBookmarkRequest updateBookmarkRequest) {
         this.page = updateBookmarkRequest.getPage();
         this.contents = updateBookmarkRequest.getContent();
-    }
-
-    public List<Reaction> getReactions() {
-        return bookmarkReactions.stream()
-                .map(BookmarkReaction::getReaction)
-                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepository.java
@@ -9,4 +9,6 @@ public interface BookmarkCustomRepository {
 
     List<Bookmark> findAllByFilter(Long bookId, BookmarkFilter bookmarkFilter);
 
+    List<Bookmark> findAllByTopicId(Long topicId);
+
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepositoryImpl.java
@@ -29,13 +29,23 @@ public class BookmarkCustomRepositoryImpl implements BookmarkCustomRepository {
     public List<Bookmark> findAllByFilter(Long bookId, BookmarkFilter bookmarkFilter) {
         return jpaQueryFactory
                 .selectFrom(bookmark)
-                .innerJoin(bookmark.writer, member)
-                .fetchJoin()
+                .innerJoin(bookmark.writer, member).fetchJoin()
                 .innerJoin(bookmark.topic, topic)
                 .innerJoin(topic.chapter, chapter)
                 .innerJoin(chapter.book, book)
-                .where(book.id.eq(bookId), createPageCondition(bookmarkFilter), createTimeCondition(bookmarkFilter))
+                .where(book.id.eq(bookId),
+                        createPageCondition(bookmarkFilter),
+                        createTimeCondition(bookmarkFilter))
                 .orderBy(createOrder(bookmarkFilter))
+                .fetch();
+    }
+
+    @Override
+    public List<Bookmark> findAllByTopicId(Long topicId) {
+        return jpaQueryFactory
+                .selectFrom(bookmark)
+                .innerJoin(bookmark.writer, member).fetchJoin()
+                .where(bookmark.topic.id.eq(topicId))
                 .fetch();
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkRepository.java
@@ -1,11 +1,6 @@
 package codesquad.bookkbookk.domain.bookmark.repository;
 
-import java.time.Instant;
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
@@ -14,21 +9,5 @@ import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkCustomRepository {
 
     boolean existsByIdAndWriterId(Long bookmarkId, Long writerId);
-
-    List<Bookmark> findAllByTopicId(Long topicId);
-
-    @Query("SELECT b " +
-            "FROM Bookmark b " +
-            "WHERE b.page >= :startPage " +
-            "AND b.page <= :endPage " +
-            "ORDER BY b.page ASC")
-    List<Bookmark> findAllByPages(@Param("startPage") Integer startPage, @Param("endPage") Integer endPage);
-
-    @Query("SELECT b " +
-            "FROM Bookmark b " +
-            "WHERE b.updatedTime >= :startTime " +
-            "AND b.updatedTime <= :endTime " +
-            "ORDER BY b.page ASC")
-    List<Bookmark> findAllByUpdatedTime(@Param("startTime") Instant startTime, @Param("endTime") Instant endTime);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
@@ -123,10 +123,7 @@ public class BookmarkService {
     public ReadReactionsResponse readBookmarkReactions(Long memberId, Long bookmarkId) {
         authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
 
-        Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(BookmarkNotFoundException::new);
-        List<BookmarkReaction> bookmarkReactions = bookmark.getBookmarkReactions();
-
-        return ReadReactionsResponse.fromBookmarkReactions(bookmarkReactions);
+        return ReadReactionsResponse.fromBookmarkReactions(bookmarkReactionRepository.findAllByBookmarkId(bookmarkId));
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.chapter.data.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -43,13 +44,17 @@ public class Chapter {
 
     private String title;
 
-    @OneToMany(mappedBy = "chapter")
+    @OneToMany(mappedBy = "chapter", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Topic> topics = new ArrayList<>();
 
     public Chapter(Book book, String title) {
         this.book = book;
         this.title = title;
         this.status = Status.BEFORE_READING;
+    }
+
+    public boolean addTopic(Topic topic) {
+        return this.topics.add(topic);
     }
 
     public Chapter update(UpdateChapterRequest request) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -38,6 +38,9 @@ public class Chapter {
     @JoinColumn(name = "book_id")
     private Book book;
 
+    @Column(name = "book_id", nullable = false, insertable = false, updatable = false)
+    private Long bookId;
+
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private Status status;
@@ -49,6 +52,7 @@ public class Chapter {
 
     public Chapter(Book book, String title) {
         this.book = book;
+        if (book != null) this.bookId = book.getId();
         this.title = title;
         this.status = Status.BEFORE_READING;
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -32,6 +32,7 @@ public class Chapter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chapter_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -34,8 +34,8 @@ public class Chapter {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
     @Column(name = "book_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepository.java
@@ -1,0 +1,12 @@
+package codesquad.bookkbookk.domain.chapter.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.common.type.Status;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+
+public interface ChapterCustomRepository {
+
+    List<Chapter> findAllByBookIdAndStatus(Long bookId, Status status);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
@@ -1,0 +1,46 @@
+package codesquad.bookkbookk.domain.chapter.repository;
+
+import static codesquad.bookkbookk.domain.bookmark.data.entity.QBookmark.*;
+import static codesquad.bookkbookk.domain.chapter.data.entity.QChapter.*;
+import static codesquad.bookkbookk.domain.topic.data.entity.QTopic.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.common.type.Status;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // TODO: 쿼리 성능 개선하기
+    @Override
+    public List<Chapter> findAllByBookIdAndStatus(Long bookId, Status status) {
+        return jpaQueryFactory
+                .selectFrom(chapter)
+                .leftJoin(chapter.topics, topic)
+                .leftJoin(topic.bookmarks, bookmark)
+                .leftJoin(bookmark.writer)
+                .where(chapter.book.id.eq(bookId),
+                        createChapterStatusCondition(status))
+                .distinct()
+                .fetch();
+    }
+
+    private BooleanExpression createChapterStatusCondition(Status status) {
+        if (status == null) {
+            return null;
+        }
+        return chapter.status.eq(status);
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterRepository.java
@@ -4,13 +4,10 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import codesquad.bookkbookk.common.type.Status;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 
-public interface ChapterRepository extends JpaRepository<Chapter, Long> {
+public interface ChapterRepository extends JpaRepository<Chapter, Long>, ChapterCustomRepository{
 
     List<Chapter> findAllByBookId(Long bookId);
-
-    List<Chapter> findAllByBookIdAndStatus(Long bookId, Status status);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
@@ -62,10 +62,13 @@ public class ChapterService {
     public List<ReadChapterResponse> readChapters(Long memberId, Long bookId, int chapterStatusId) {
         authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
 
+        Status chapterStatus;
         if (chapterStatusId == ALL_STATUS) {
-            return ReadChapterResponse.from(chapterRepository.findAllByBookId(bookId));
+            chapterStatus = null;
+        } else {
+            chapterStatus = Status.of(chapterStatusId);
         }
-        Status chapterStatus = Status.of(chapterStatusId);
+
         return ReadChapterResponse.from(chapterRepository.findAllByBookIdAndStatus(bookId, chapterStatus));
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
@@ -36,8 +36,8 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bookmark_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bookmark_id", nullable = false)
     private Bookmark bookmark;
 
     @Column(name = "bookmark_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
@@ -40,9 +40,15 @@ public class Comment {
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
 
+    @Column(name = "bookmark_id", nullable = false, insertable = false, updatable = false)
+    private Long bookmarkId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
+
+    @Column(name = "writer_id", nullable = false, insertable = false, updatable = false)
+    private Long writerId;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String contents;
@@ -60,7 +66,9 @@ public class Comment {
 
     public Comment(Bookmark bookmark, Member writer, String contents) {
         this.bookmark = bookmark;
+        if (bookmark != null) this.bookmarkId = bookmark.getId();
         this.writer = writer;
+        if (writer != null) this.writerId = writer.getId();
         this.contents = contents;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
@@ -34,6 +34,7 @@ public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -34,28 +35,37 @@ public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private Member writer;
+
     @Column(columnDefinition = "TEXT", nullable = false)
     private String contents;
+
     @CreationTimestamp
     @Column(columnDefinition = "TIMESTAMP", nullable = false)
     private Instant createdTime;
     @UpdateTimestamp
+
     @Column(columnDefinition = "TIMESTAMP", nullable = false)
     private Instant updatedTime;
 
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     List<CommentReaction> commentReactions = new ArrayList<>();
 
     public Comment(Bookmark bookmark, Member writer, String contents) {
         this.bookmark = bookmark;
         this.writer = writer;
         this.contents = contents;
+    }
+
+    public boolean addReaction(CommentReaction commentReaction) {
+        return this.commentReactions.add(commentReaction);
     }
 
     public void updateComment(UpdateCommentRequest updateCommentRequest) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.domain.comment.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+
+public interface CommentCustomRepository {
+
+    List<Comment> findAllByBookmarkId(Long bookmarkId);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package codesquad.bookkbookk.domain.comment.repository;
+
+import static codesquad.bookkbookk.domain.comment.data.entity.QComment.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentCustomRepositoryImpl implements CommentCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Comment> findAllByBookmarkId(Long bookmarkId) {
+        return jpaQueryFactory
+                .selectFrom(comment)
+                .innerJoin(comment.writer).fetchJoin()
+                .where(comment.bookmark.id.eq(bookmarkId))
+                .fetch();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {
 
     boolean existsByIdAndWriterId(Long commentId, Long writerId);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
@@ -99,19 +99,14 @@ public class CommentService {
     public List<ReadCommentResponse> readComments(Long memberId, Long bookmarkId) {
         authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
 
-        Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(BookmarkNotFoundException::new);
-
-        return ReadCommentResponse.from(bookmark.getComments());
+        return ReadCommentResponse.from(commentRepository.findAllByBookmarkId(bookmarkId));
     }
 
     @Transactional(readOnly = true)
     public ReadReactionsResponse readCommentReactions(Long memberId, Long commentId) {
         authorizationService.authorizeBookClubMembershipByCommentId(memberId, commentId);
 
-        Comment comment = commentRepository.findById(commentId).orElseThrow(BookmarkNotFoundException::new);
-        List<CommentReaction> commentReactions = comment.getCommentReactions();
-
-        return ReadReactionsResponse.fromCommentReactions(commentReactions);
+        return ReadReactionsResponse.fromCommentReactions(commentReactionRepository.findAllByCommentId(commentId));
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
@@ -27,8 +27,8 @@ public class Gathering {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
     @Column(name = "book_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
@@ -25,6 +25,7 @@ public class Gathering {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "gathering_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/data/entity/Gathering.java
@@ -31,6 +31,9 @@ public class Gathering {
     @JoinColumn(name = "book_id")
     private Book book;
 
+    @Column(name = "book_id", nullable = false, insertable = false, updatable = false)
+    private Long bookId;
+
     @Column(columnDefinition = "TIMESTAMP", nullable = false)
     private Instant startTime;
 
@@ -39,6 +42,7 @@ public class Gathering {
 
     public Gathering(Book book, Instant startTime, String place) {
         this.book = book;
+        if (book != null) this.bookId = book.getId();
         this.startTime = startTime;
         this.place = place;
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringCustomRepository.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.domain.gathering.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
+
+public interface GatheringCustomRepository {
+
+    List<Gathering> findAllByBookClubId(Long bookClubId);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringCustomRepositoryImpl.java
@@ -1,0 +1,33 @@
+package codesquad.bookkbookk.domain.gathering.repository;
+
+import static codesquad.bookkbookk.domain.book.data.entity.QBook.*;
+import static codesquad.bookkbookk.domain.bookclub.data.entity.QBookClub.*;
+import static codesquad.bookkbookk.domain.gathering.data.entity.QGathering.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class GatheringCustomRepositoryImpl implements GatheringCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Gathering> findAllByBookClubId(Long bookClubId) {
+        return jpaQueryFactory
+                .selectFrom(gathering)
+                .innerJoin(gathering.book, book).fetchJoin()
+                .innerJoin(book.bookClub, bookClub)
+                .where(bookClub.id.eq(bookClubId))
+                .fetch();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/repository/GatheringRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 
-public interface GatheringRepository extends JpaRepository<Gathering, Long> {
+public interface GatheringRepository extends JpaRepository<Gathering, Long>, GatheringCustomRepository {
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
@@ -54,12 +54,7 @@ public class GatheringService {
     public List<ReadGatheringResponse> readGatherings(Long memberId, Long bookClubId) {
         authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
 
-        BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
-        List<Gathering> gatherings = bookClub.getBooks().stream()
-                .flatMap(book -> book.getGatherings().stream())
-                .collect(Collectors.toUnmodifiableList());
-
-        return ReadGatheringResponse.from(gatherings);
+        return ReadGatheringResponse.from(gatheringRepository.findAllByBookClubId(bookClubId));
     }
 
     @Transactional

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -26,6 +26,7 @@ public class BookClubMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_club_member_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -28,14 +28,14 @@ public class BookClubMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_club_id")
     private BookClub bookClub;
 
     @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
     private Long bookClubId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -28,15 +28,15 @@ public class BookClubMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_club_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_club_id", nullable = false)
     private BookClub bookClub;
 
     @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
     private Long bookClubId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Column(name = "member_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.mapping.entity;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -31,13 +32,21 @@ public class BookClubMember {
     @JoinColumn(name = "book_club_id")
     private BookClub bookClub;
 
+    @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
+    private Long bookClubId;
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(name = "member_id", nullable = false, insertable = false, updatable = false)
+    private Long memberId;
+
     public BookClubMember(BookClub bookClub, Member member) {
         this.bookClub = bookClub;
+        if (bookClub != null) this.bookClubId = getBookClubId();
         this.member = member;
+        if (member != null) this.memberId = member.getId();
     }
 
     public static List<Member> toMembers(List<BookClubMember> bookClubMembers) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -27,11 +27,11 @@ public class BookClubMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "book_club_id")
     private BookClub bookClub;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -28,15 +28,15 @@ public class BookmarkReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bookmark_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bookmark_id", nullable = false)
     private Bookmark bookmark;
 
     @Column(name = "bookmark_id", nullable = false, insertable = false, updatable = false)
     private Long bookmarkId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reactor_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reactor_id", nullable = false)
     private Member reactor;
 
     @Column(name = "reactor_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -27,12 +27,15 @@ public class BookmarkReaction {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne(fetch = FetchType.LAZY)
+
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
-    @ManyToOne(fetch = FetchType.LAZY)
+
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
+
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private Reaction reaction;

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -28,15 +28,14 @@ public class BookmarkReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: Bookmark의 Reaction읽을 때 자동으로 가져온다. 생각하십시오.
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
 
     @Column(name = "bookmark_id", nullable = false, insertable = false, updatable = false)
     private Long bookmarkId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -32,9 +32,15 @@ public class BookmarkReaction {
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;
 
+    @Column(name = "bookmark_id", nullable = false, insertable = false, updatable = false)
+    private Long bookmarkId;
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
+
+    @Column(name = "reactor_id", nullable = false, insertable = false, updatable = false)
+    private Long reactorId;
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
@@ -42,7 +48,9 @@ public class BookmarkReaction {
 
     public BookmarkReaction(Bookmark bookmark, Member reactor, Reaction reaction) {
         this.bookmark = bookmark;
+        if (bookmark != null) this.bookmarkId = bookmark.getId();
         this.reactor = reactor;
+        if (reactor != null) this.reactorId = reactor.getId();
         this.reaction = reaction;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -26,6 +26,7 @@ public class BookmarkReaction {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_reaction_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookmarkReaction.java
@@ -28,6 +28,7 @@ public class BookmarkReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // TODO: Bookmark의 Reaction읽을 때 자동으로 가져온다. 생각하십시오.
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "bookmark_id")
     private Bookmark bookmark;

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -28,15 +28,15 @@ public class CommentReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id", nullable = false)
     private Comment comment;
 
     @Column(name = "comment_id", nullable = false, insertable = false, updatable = false)
     private Long commentId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reactor_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reactor_id", nullable = false)
     private Member reactor;
 
     @Column(name = "reactor_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -26,6 +26,7 @@ public class CommentReaction {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_reaction_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -28,15 +28,14 @@ public class CommentReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: BookmarkReaction과 마찬가지로 fetch 전략 생각해볼것
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
     @Column(name = "comment_id", nullable = false, insertable = false, updatable = false)
     private Long commentId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -27,11 +27,11 @@ public class CommentReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -1,5 +1,6 @@
 package codesquad.bookkbookk.domain.mapping.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -31,16 +32,24 @@ public class CommentReaction {
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
+    @Column(name = "comment_id", nullable = false, insertable = false, updatable = false)
+    private Long commentId;
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
+
+    @Column(name = "reactor_id", nullable = false, insertable = false, updatable = false)
+    private Long reactorId;
 
     @Enumerated(value = EnumType.STRING)
     private Reaction reaction;
 
     public CommentReaction(Comment comment, Member reactor, Reaction reaction) {
         this.comment = comment;
+        if (comment != null) this.commentId = comment.getId();
         this.reactor = reactor;
+        if (reactor != null) this.reactorId = reactor.getId();
         this.reaction = reaction;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/CommentReaction.java
@@ -28,6 +28,7 @@ public class CommentReaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // TODO: BookmarkReaction과 마찬가지로 fetch 전략 생각해볼것
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "comment_id")
     private Comment comment;

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -28,15 +28,15 @@ public class MemberBook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Column(name = "member_id", nullable = false, insertable = false, updatable = false)
     private Long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
     @Column(name = "book_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -1,5 +1,8 @@
 package codesquad.bookkbookk.domain.mapping.entity;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -25,14 +28,14 @@ public class MemberBook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Column(name = "member_id", nullable = false, insertable = false, updatable = false)
     private Long memberId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
     private Book book;
 
@@ -44,6 +47,12 @@ public class MemberBook {
         if (member != null) this.memberId = member.getId();
         this.book = book;
         if (book != null) this.bookId = book.getId();
+    }
+
+    public static List<MemberBook> of(Member member, List<Book> books) {
+        return books.stream()
+                .map(book -> new MemberBook(member, book))
+                .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -24,11 +24,11 @@ public class MemberBook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "book_id")
     private Book book;
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -1,5 +1,6 @@
 package codesquad.bookkbookk.domain.mapping.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -28,13 +29,21 @@ public class MemberBook {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(name = "member_id", nullable = false, insertable = false, updatable = false)
+    private Long memberId;
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "book_id")
     private Book book;
 
+    @Column(name = "book_id", nullable = false, insertable = false, updatable = false)
+    private Long bookId;
+
     public MemberBook(Member member, Book book) {
         this.member = member;
+        if (member != null) this.memberId = member.getId();
         this.book = book;
+        if (book != null) this.bookId = book.getId();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/MemberBook.java
@@ -26,6 +26,7 @@ public class MemberBook {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_book_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionCustomRepository.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.domain.mapping.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.domain.mapping.entity.BookmarkReaction;
+
+public interface BookmarkReactionCustomRepository {
+
+    List<BookmarkReaction> findAllByBookmarkId(Long bookmarkId);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionCustomRepositoryImpl.java
@@ -1,0 +1,31 @@
+package codesquad.bookkbookk.domain.mapping.repository;
+
+import static codesquad.bookkbookk.domain.mapping.entity.QBookmarkReaction.*;
+import static codesquad.bookkbookk.domain.member.data.entity.QMember.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.mapping.entity.BookmarkReaction;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkReactionCustomRepositoryImpl implements BookmarkReactionCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<BookmarkReaction> findAllByBookmarkId(Long bookmarkId) {
+        return jpaQueryFactory
+                .selectFrom(bookmarkReaction)
+                .innerJoin(bookmarkReaction.reactor, member).fetchJoin()
+                .where(bookmarkReaction.bookmark.id.eq(bookmarkId))
+                .fetch();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/BookmarkReactionRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import codesquad.bookkbookk.common.type.Reaction;
 import codesquad.bookkbookk.domain.mapping.entity.BookmarkReaction;
 
-public interface BookmarkReactionRepository extends JpaRepository<BookmarkReaction, Long> {
+public interface BookmarkReactionRepository extends JpaRepository<BookmarkReaction, Long>, BookmarkReactionCustomRepository {
 
     public boolean existsByBookmarkIdAndReactorIdAndReaction(Long bookmarkId, Long reactorId, Reaction reaction);
     public Optional<BookmarkReaction> findByBookmarkIdAndReactorIdAndReaction(Long bookmarkId, Long reactorId,

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionCustomRepository.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.domain.mapping.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.domain.mapping.entity.CommentReaction;
+
+public interface CommentReactionCustomRepository {
+
+    List<CommentReaction> findAllByCommentId(Long commentId);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionCustomRepositoryImpl.java
@@ -1,0 +1,31 @@
+package codesquad.bookkbookk.domain.mapping.repository;
+
+import static codesquad.bookkbookk.domain.mapping.entity.QCommentReaction.*;
+import static codesquad.bookkbookk.domain.member.data.entity.QMember.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codesquad.bookkbookk.domain.mapping.entity.CommentReaction;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentReactionCustomRepositoryImpl implements CommentReactionCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CommentReaction> findAllByCommentId(Long commentId) {
+        return jpaQueryFactory
+                .selectFrom(commentReaction)
+                .innerJoin(commentReaction.reactor, member).fetchJoin()
+                .where(commentReaction.comment.id.eq(commentId))
+                .fetch();
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/repository/CommentReactionRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import codesquad.bookkbookk.common.type.Reaction;
 import codesquad.bookkbookk.domain.mapping.entity.CommentReaction;
 
-public interface CommentReactionRepository extends JpaRepository<CommentReaction, Long> {
+public interface CommentReactionRepository extends JpaRepository<CommentReaction, Long>, CommentReactionCustomRepository {
 
     boolean existsByCommentIdAndReactorIdAndReaction(Long commentId, Long reactorId, Reaction reaction);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -86,8 +86,8 @@ public class Member {
         return this.memberBookClubs.add(bookClubMember);
     }
 
-    public boolean addBook(MemberBook memberBook) {
-        return this.memberBooks.add(memberBook);
+    public boolean addBook(Book book) {
+        return this.memberBooks.add(new MemberBook(this, book));
     }
     public boolean addBooks(List<MemberBook> memberBooks) {
         return this.memberBooks.addAll(memberBooks);

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -33,6 +33,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -4,16 +4,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import codesquad.bookkbookk.domain.auth.data.type.LoginType;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.entity.MemberBook;
@@ -45,10 +48,10 @@ public class Member {
     @Column(nullable = false)
     private String profileImageUrl;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookClubMember> memberBookClubs = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberBook> memberBooks = new ArrayList<>();
 
     @Builder
@@ -71,6 +74,19 @@ public class Member {
         return memberBookClubs.stream()
                 .map(BookClubMember::getBookClub)
                 .collect(Collectors.toUnmodifiableList());
+    }
+    public List<Book> getBooks() {
+        return memberBooks.stream()
+                .map(MemberBook::getBook)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public boolean addBookClub(BookClubMember bookClubMember) {
+        return this.memberBookClubs.add(bookClubMember);
+    }
+
+    public boolean addBook(MemberBook memberBook) {
+        return this.memberBooks.add(memberBook);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/member/data/entity/Member.java
@@ -88,5 +88,8 @@ public class Member {
     public boolean addBook(MemberBook memberBook) {
         return this.memberBooks.add(memberBook);
     }
+    public boolean addBooks(List<MemberBook> memberBooks) {
+        return this.memberBooks.addAll(memberBooks);
+    }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -30,8 +30,8 @@ public class Topic {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chapter_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "chapter_id", nullable = false)
     private Chapter chapter;
 
     @Column(name = "chapter_id", nullable = false, insertable = false, updatable = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.topic.data.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -34,12 +35,16 @@ public class Topic {
 
     private String title;
 
-    @OneToMany(mappedBy = "topic")
+    @OneToMany(mappedBy = "topic", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Bookmark> bookmarks = new ArrayList<>();
 
     public Topic(Chapter chapter, String title) {
         this.chapter = chapter;
         this.title = title;
+    }
+
+    public boolean addBookmark(Bookmark bookmark) {
+        return this.bookmarks.add(bookmark);
     }
 
     public void updateTitle(String title){

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -28,6 +28,7 @@ public class Topic {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "topic_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -33,6 +34,9 @@ public class Topic {
     @JoinColumn(name = "chapter_id")
     private Chapter chapter;
 
+    @Column(name = "chapter_id", nullable = false, insertable = false, updatable = false)
+    private Long chapterId;
+
     private String title;
 
     @OneToMany(mappedBy = "topic", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -40,6 +44,7 @@ public class Topic {
 
     public Topic(Chapter chapter, String title) {
         this.chapter = chapter;
+        if (chapter != null) this.chapterId = chapter.getId();
         this.title = title;
     }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
@@ -40,6 +40,7 @@ public class TopicService {
         return new CreateTopicResponse(topic.getId());
     }
 
+    @Transactional(readOnly = true)
     public List<ReadTopicResponse> readTopicLIst(Long memberId, Long chapterId) {
         authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
 
@@ -48,7 +49,7 @@ public class TopicService {
         return ReadTopicResponse.from(topicList);
     }
 
-    @Transactional(readOnly = false)
+    @Transactional
     public void updateTitle(Long memberId, Long topicId, UpdateTopicTitleRequest request) {
         authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
 

--- a/be/src/main/resources/schema.sql
+++ b/be/src/main/resources/schema.sql
@@ -13,12 +13,12 @@ DROP TABLE IF EXISTS member;
 
 CREATE TABLE member
 (
-    id                BIGINT        NOT NULL AUTO_INCREMENT,
+    member_id         BIGINT        NOT NULL AUTO_INCREMENT,
     login_type        VARCHAR(255)  NOT NULL,
     email             VARCHAR(255)  NOT NULL,
     nickname          VARCHAR(255)  NOT NULL,
     profile_image_url VARCHAR(1000) NOT NULL,
-    CONSTRAINT pk_member PRIMARY KEY (id),
+    CONSTRAINT pk_member PRIMARY KEY (member_id),
     CONSTRAINT uk_member_email UNIQUE KEY (email),
     CONSTRAINT uk_member_nickname UNIQUE KEY (nickname),
     CONSTRAINT ck_member_login_type CHECK (login_type IN ('GOOGLE'))
@@ -26,7 +26,7 @@ CREATE TABLE member
 
 CREATE TABLE book_club
 (
-    id                      BIGINT        NOT NULL AUTO_INCREMENT,
+    book_club_id            BIGINT        NOT NULL AUTO_INCREMENT,
     creator_id              BIGINT        NOT NULL,
     status                  VARCHAR(255)  NOT NULL,
     name                    VARCHAR(255)  NOT NULL,
@@ -34,25 +34,25 @@ CREATE TABLE book_club
     created_time            TIMESTAMP     NOT NULL,
     closed_time             TIMESTAMP     NULL,
     upcoming_gathering_time TIMESTAMP     NULL,
-    CONSTRAINT pk_book_club PRIMARY KEY (id),
-    CONSTRAINT fk_book_club_member FOREIGN KEY (creator_id) REFERENCES member (id),
+    CONSTRAINT pk_book_club PRIMARY KEY (book_club_id),
+    CONSTRAINT fk_book_club_member FOREIGN KEY (creator_id) REFERENCES member (member_id),
     CONSTRAINT uk_book_club_name UNIQUE KEY (name),
     CONSTRAINT ck_book_club_status CHECK (status IN ('OPEN', 'CLOSED'))
 );
 
 CREATE TABLE book_club_member
 (
-    id           BIGINT NOT NULL AUTO_INCREMENT,
-    book_club_id BIGINT NOT NULL,
-    member_id    BIGINT NOT NULL,
-    CONSTRAINT pk_book_club_member PRIMARY KEY (id),
-    CONSTRAINT fk_book_club_member_book_club FOREIGN KEY (book_club_id) REFERENCES book_club (id),
-    CONSTRAINT fk_book_club_member_member FOREIGN KEY (member_id) REFERENCES member (id)
+    book_club_member_id BIGINT NOT NULL AUTO_INCREMENT,
+    book_club_id        BIGINT NOT NULL,
+    member_id           BIGINT NOT NULL,
+    CONSTRAINT pk_book_club_member PRIMARY KEY (book_club_member_id),
+    CONSTRAINT fk_book_club_member_book_club FOREIGN KEY (book_club_id) REFERENCES book_club (book_club_id),
+    CONSTRAINT fk_book_club_member_member FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
 CREATE TABLE book
 (
-    id           BIGINT        NOT NULL AUTO_INCREMENT,
+    book_id      BIGINT        NOT NULL AUTO_INCREMENT,
     book_club_id BIGINT        NOT NULL,
     status       VARCHAR(255)  NOT NULL,
     isbn         VARCHAR(255)  NOT NULL,
@@ -60,98 +60,98 @@ CREATE TABLE book
     cover        VARCHAR(1000) NOT NULL,
     author       VARCHAR(255)  NOT NULL,
     category     VARCHAR(255)  NOT NULL,
-    CONSTRAINT pk_book PRIMARY KEY (id),
-    CONSTRAINT fk_book_book_club FOREIGN KEY (book_club_id) REFERENCES book_club (id),
+    CONSTRAINT pk_book PRIMARY KEY (book_id),
+    CONSTRAINT fk_book_book_club FOREIGN KEY (book_club_id) REFERENCES book_club (book_club_id),
     CONSTRAINT ck_book_status CHECK (status IN ('BEFORE_READING', 'READING', 'AFTER_READING'))
 );
 
 CREATE TABLE member_book
 (
-    id        BIGINT NOT NULL AUTO_INCREMENT,
-    member_id BIGINT NOT NULL,
-    book_id   BIGINT NOT NULL,
-    CONSTRAINT pk_member_book PRIMARY KEY (id),
-    CONSTRAINT fk_member_book_member FOREIGN KEY (member_id) REFERENCES member (id),
-    CONSTRAINT fk_member_book_book FOREIGN KEY (book_id) REFERENCES book (id)
+    member_book_id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id      BIGINT NOT NULL,
+    book_id        BIGINT NOT NULL,
+    CONSTRAINT pk_member_book PRIMARY KEY (member_book_id),
+    CONSTRAINT fk_member_book_member FOREIGN KEY (member_id) REFERENCES member (member_id),
+    CONSTRAINT fk_member_book_book FOREIGN KEY (book_id) REFERENCES book (book_id)
 );
 
 CREATE TABLE gathering
 (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
-    book_id    BIGINT       NOT NULL,
-    start_time TIMESTAMP    NOT NULL,
-    place      VARCHAR(255) NOT NULL,
-    CONSTRAINT pk_gathering PRIMARY KEY (id),
-    CONSTRAINT fk_gathering_book FOREIGN KEY (book_id) REFERENCES book (id)
+    gathering_id BIGINT       NOT NULL AUTO_INCREMENT,
+    book_id      BIGINT       NOT NULL,
+    start_time   TIMESTAMP    NOT NULL,
+    place        VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_gathering PRIMARY KEY (gathering_id),
+    CONSTRAINT fk_gathering_book FOREIGN KEY (book_id) REFERENCES book (book_id)
 );
 
 CREATE TABLE chapter
 (
-    id      BIGINT       NOT NULL AUTO_INCREMENT,
-    book_id BIGINT       NOT NULL,
-    status  VARCHAR(255) NOT NULL,
-    title   VARCHAR(255) NULL,
-    CONSTRAINT pk_chapter PRIMARY KEY (id),
-    CONSTRAINT fk_chapter_book FOREIGN KEY (book_id) REFERENCES book (id),
+    chapter_id BIGINT       NOT NULL AUTO_INCREMENT,
+    book_id    BIGINT       NOT NULL,
+    status     VARCHAR(255) NOT NULL,
+    title      VARCHAR(255) NULL,
+    CONSTRAINT pk_chapter PRIMARY KEY (chapter_id),
+    CONSTRAINT fk_chapter_book FOREIGN KEY (book_id) REFERENCES book (book_id),
     CONSTRAINT ck_chapter_status CHECK (status IN ('BEFORE_READING', 'READING', 'AFTER_READING'))
 );
 
 CREATE TABLE topic
 (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    topic_id   BIGINT       NOT NULL AUTO_INCREMENT,
     chapter_id BIGINT       NOT NULL,
     title      VARCHAR(255) NULL,
-    CONSTRAINT pk_topic PRIMARY KEY (id),
-    CONSTRAINT fk_topic_chapter FOREIGN KEY (chapter_id) REFERENCES chapter (id)
+    CONSTRAINT pk_topic PRIMARY KEY (topic_id),
+    CONSTRAINT fk_topic_chapter FOREIGN KEY (chapter_id) REFERENCES chapter (chapter_id)
 );
 
 CREATE TABLE bookmark
 (
-    id           BIGINT       NOT NULL AUTO_INCREMENT,
-    topic_id     BIGINT       NOT NULL,
-    writer_id    BIGINT       NOT NULL,
-    page         INT          NOT NULL,
-    contents     TEXT         NOT NULL,
-    created_time TIMESTAMP    NOT NULL,
-    updated_time TIMESTAMP    NULL,
-    CONSTRAINT pk_bookmark PRIMARY KEY (id),
-    CONSTRAINT fk_bookmark_topic FOREIGN KEY (topic_id) REFERENCES topic (id),
-    CONSTRAINT fk_bookmark_member FOREIGN KEY (writer_id) REFERENCES member (id)
+    bookmark_id  BIGINT    NOT NULL AUTO_INCREMENT,
+    topic_id     BIGINT    NOT NULL,
+    writer_id    BIGINT    NOT NULL,
+    page         INT       NOT NULL,
+    contents     TEXT      NOT NULL,
+    created_time TIMESTAMP NOT NULL,
+    updated_time TIMESTAMP NULL,
+    CONSTRAINT pk_bookmark PRIMARY KEY (bookmark_id),
+    CONSTRAINT fk_bookmark_topic FOREIGN KEY (topic_id) REFERENCES topic (topic_id),
+    CONSTRAINT fk_bookmark_member FOREIGN KEY (writer_id) REFERENCES member (member_id)
 );
 
 CREATE TABLE bookmark_reaction
 (
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    bookmark_id BIGINT       NOT NULL,
-    reactor_id  BIGINT       NOT NULL,
-    reaction    VARCHAR(255) NOT NULL,
-    CONSTRAINT pk_bookmark_reaction PRIMARY KEY (id),
-    CONSTRAINT fk_bookmark_reaction_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (id),
-    CONSTRAINT fk_bookmark_reaction_member FOREIGN KEY (reactor_id) REFERENCES member (id),
+    bookmark_reaction_id BIGINT       NOT NULL AUTO_INCREMENT,
+    bookmark_id          BIGINT       NOT NULL,
+    reactor_id           BIGINT       NOT NULL,
+    reaction             VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_bookmark_reaction PRIMARY KEY (bookmark_reaction_id),
+    CONSTRAINT fk_bookmark_reaction_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (bookmark_id),
+    CONSTRAINT fk_bookmark_reaction_member FOREIGN KEY (reactor_id) REFERENCES member (member_id),
     CONSTRAINT ck_bookmark_reaction_reaction CHECK (reaction IN ('LIKE', 'LOVE', 'CLAP', 'CONGRATULATION', 'ROCKET'))
 );
 
 CREATE TABLE comment
 (
-    id           BIGINT    NOT NULL AUTO_INCREMENT,
+    comment_id   BIGINT    NOT NULL AUTO_INCREMENT,
     bookmark_id  BIGINT    NOT NULL,
     writer_id    BIGINT    NOT NULL,
     contents     TEXT      NOT NULL,
     created_time TIMESTAMP NOT NULL,
     updated_time TIMESTAMP NULL,
-    CONSTRAINT pk_comment PRIMARY KEY (id),
-    CONSTRAINT fk_comment_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (id),
-    CONSTRAINT fk_comment_member FOREIGN KEY (writer_id) REFERENCES member (id)
+    CONSTRAINT pk_comment PRIMARY KEY (comment_id),
+    CONSTRAINT fk_comment_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (bookmark_id),
+    CONSTRAINT fk_comment_member FOREIGN KEY (writer_id) REFERENCES member (member_id)
 );
 
 CREATE TABLE comment_reaction
 (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
-    comment_id BIGINT       NOT NULL,
-    reactor_id BIGINT       NOT NULL,
-    reaction   VARCHAR(255) NOT NULL,
-    CONSTRAINT pk_comment_reaction PRIMARY KEY (id),
-    CONSTRAINT fk_comment_reaction_comment FOREIGN KEY (comment_id) REFERENCES comment (id),
-    CONSTRAINT fk_comment_reaction_member FOREIGN KEY (reactor_id) REFERENCES member (id),
+    comment_reaction_id BIGINT       NOT NULL AUTO_INCREMENT,
+    comment_id          BIGINT       NOT NULL,
+    reactor_id          BIGINT       NOT NULL,
+    reaction            VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_comment_reaction PRIMARY KEY (comment_reaction_id),
+    CONSTRAINT fk_comment_reaction_comment FOREIGN KEY (comment_id) REFERENCES comment (comment_id),
+    CONSTRAINT fk_comment_reaction_member FOREIGN KEY (reactor_id) REFERENCES member (member_id),
     CONSTRAINT ck_comment_reaction_reaction CHECK (reaction IN ('LIKE', 'LOVE', 'CLAP', 'CONGRATULATION', 'ROCKET'))
 );


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?
- `QueryDsl`을 사용하여 조회 쿼리를 최적화 했습니다.
  - fetch join을 사용하여 조회시 최소한의 쿼리를 만들도록 했습니다.
  - 일대다 관계의 경우, 타겟 엔티티만 조회하고 `Hibernate.initialize()`를 사용하여 초기화도록 변경했습니다.
  - `status`에 따라 조회 조건이 달라지는데, 동적 쿼리를 작성하여 
- JPA 기능을 사용하여 엔티티를 알맞게 관리했습니다.
  - 다대일 관계에서는 다음과 같이 관리합니다.
    ```java
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "book_club_id")
    private BookClub bookClub;

    @Column(name = "book_club_id", nullable = false, , insertable = false,  updatable = false)
    private Long bookClubId;
    ```
  - 부모가 자식을 관리하는 일대다 관계에서는 다음과 깉이 관리합니다.
    ```java
    @OneToMany(mappedBy = "bookClub", fetch = FetchType.LAZY,  cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Book> books = new ArrayList<>();
    ```
  - 부모가 자식을 관리하지 않는 일대다 관계에서는 다음과 같이 관리합니다.
    ```java
    @OneToMany(mappedBy = "bookClub", fetch = FetchType.LAZY)
    private List<Book> books = new ArrayList<>();
    ```
  - 매핑 엔티티는 다음과 같이 관리합니다.
    - 매핑 엔티티
      ```java
      @ManyToOne(fetch = FetchType.LAZY, optional = false)
      @JoinColumn(name = "book_club_id", nullable = false)
      private BookClub bookClub;

      @Column(name = "book_club_id", nullable = false, insertable = false, updatable = false)
      private Long bookClubId;

      @ManyToOne(fetch = FetchType.LAZY, optional = false)
      @JoinColumn(name = "member_id", nullable = false)
      private Member member;

      @Column(name = "member_id", nullable = false, insertable = false, updatable = false)
      private Long memberId;
      ``` 
    - 매핑 부모
      ```java
      @OneToMany(mappedBy = "bookClub", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
      private List<BookClubMember> bookClubMembers = new ArrayList<>();
      ```


### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- `QueryDsl`
  - `@Query`를 사용하여 `JPQL`을 만들어 사용할 수 있습니다. 다만 이 경우 동적 쿼리를 작성할 때 어려움이 있어 `QueryDsl`을 사용했습니다.
  - 일대다의 경우 `Hibernate.initialize()`를 사용하여 엔티티를 초기화하는데, 이는 중복된 엔티티가 들어감을 방지하고 쿼리를 모아서 실행하게 하기 위해섭니다.
- JPA
  - 다대일의 경우 조회용 아이디(`entityId`)필드를 만들어 JPA가 기본적으로 생성해주는 FK로 엔티티 검색하는 메소드(ex: `bookRepository.findAllByBookClubId(Long bookClubId)`에서 불필요한 Join을 없앱니다.
  - 또한 엔티티의 FK를 가져올 때도 엔티티를 조인하여서 아이디를 가져오는데(ex: `book.getBookClub.getId()`) 이 경우에도 불필요한 Join을 없앱니다.
  - 부모가 하나인 일대다 관계에서는 부모와 자식의 생명주기가 일치하도록 `cascade = CascadeType.ALL`를 사용했고 고아 객체를 자동으로 없애도록 `orphanRemoval = true`를 사용했습니다.
  - 매핑 엔티티의 경우 부모가 2개지만, 2개의 부모가 다 온전해야 매핑 엔티티가 의미가 있다고 생각했습니다. 그래서 양쪽 부모에 `cascade = CascadeType.ALL, orphanRemoval = true`를 사용했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
