### PR TITLE
Be/feat/#253 auth update

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/BookClubAuthorizationFailedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/BookClubAuthorizationFailedException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BookClubAuthorizationFailedException extends ApiException{
+
+    public BookClubAuthorizationFailedException() {
+        super(HttpStatus.UNAUTHORIZED, "북클럽 인가에 실패했습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/EntityNotFountException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/EntityNotFountException.java
@@ -1,0 +1,13 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EntityNotFountException extends ApiException {
+
+    private static final String PREDICATE = "을(를) 찾을 수 없습니다.";
+
+    public EntityNotFountException(Class<?> entity) {
+        super(HttpStatus.NOT_FOUND, entity.getSimpleName() + PREDICATE);
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/EntityNotFountException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/EntityNotFountException.java
@@ -2,12 +2,12 @@ package codesquad.bookkbookk.common.error.exception;
 
 import org.springframework.http.HttpStatus;
 
+import codesquad.bookkbookk.common.type.EntityType;
+
 public class EntityNotFountException extends ApiException {
 
-    private static final String PREDICATE = "을(를) 찾을 수 없습니다.";
-
-    public EntityNotFountException(Class<?> entity) {
-        super(HttpStatus.NOT_FOUND, entity.getSimpleName() + PREDICATE);
+    public EntityNotFountException(EntityType type) {
+        super(HttpStatus.NOT_FOUND, type.getErrorMessage());
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/common/type/EntityType.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/type/EntityType.java
@@ -1,0 +1,22 @@
+package codesquad.bookkbookk.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum EntityType {
+
+    MEMBER("MEMBER_ID", "Member를 찾을 수 없습니다."),
+    BOOK_CLUB("BOOK_CLUB_ID", "BookClub을 찾을 수 없습니다."),
+    BOOK("BOOK_ID", "Book을 찾을 수 없습니다."),
+    GATHERING("GATHERING_ID", "Gathering을 찾을 수 없습니다."),
+    CHAPTER("CHAPTER_ID", "Chapter를 찾을 수 없습니다."),
+    TOPIC("TOPIC_ID", "Topic을 찾을 수 없습니다."),
+    BOOKMARK("BOOKMARK_ID", "Bookmark를 찾을 수 없습니다."),
+    COMMENT("COMMENT_ID", "Comment를 찾을 수 없습니다.");
+
+    private final String idColumnName;
+    private final String errorMessage;
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/BookClubMemberAuthInfo.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/BookClubMemberAuthInfo.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class BookClubMemberAuthInfo {
 
-    private final Long bookClubMemberId;
     private final Long bookClubId;
     private final Long memberId;
+    private final Long entityId;
 
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/BookClubMemberAuthInfo.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/data/dto/BookClubMemberAuthInfo.java
@@ -1,0 +1,15 @@
+package codesquad.bookkbookk.domain.auth.data.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class BookClubMemberAuthInfo {
+
+    private final Long bookClubMemberId;
+    private final Long bookClubId;
+    private final Long memberId;
+
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
@@ -11,8 +11,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,58 +26,6 @@ import lombok.RequiredArgsConstructor;
 public class AuthorizationJdbcRepository {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
-
-    private RowMapper<BookClubMemberAuthInfo> createAuthRowMapper(Class<?> entity) {
-        return (resultSet, rowNum) -> {
-            Long bookClubId = getLongOrNull(resultSet, "book_club_id");
-            Long memberId = getLongOrNull(resultSet, "member_id");
-            Long entityId = getEntityIdOrNull(resultSet, entity);
-
-            return new BookClubMemberAuthInfo(bookClubId, memberId, entityId);
-        };
-    }
-
-    private Long getEntityIdOrNull(ResultSet resultSet, Class<?> entity) throws SQLException {
-        ResultSetMetaData metaData = resultSet.getMetaData();
-        String className = entity.getSimpleName();
-        String columnName = convertClassNameToColumnName(className);
-
-        for (int i = 1; i <= metaData.getColumnCount(); i++) {
-            String metaColumnName = metaData.getColumnName(i);
-
-            if (metaColumnName.equals(columnName) || metaColumnName.equals(columnName.toLowerCase())) {
-                return getLongOrNull(resultSet, columnName);
-            }
-        }
-        return null;
-    }
-
-    private Long getLongOrNull(ResultSet resultSet, String columnName) throws SQLException {
-        Long l = resultSet.getLong(columnName);
-
-        if (resultSet.wasNull()) {
-            return null;
-        }
-        return l;
-    }
-
-    private String convertClassNameToColumnName(String className) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(Character.toUpperCase(className.charAt(0)));
-        for (int i = 1; i < className.length(); i++) {
-            char c = className.charAt(i);
-
-            if (Character.isUpperCase(c)) {
-                sb.append('_');
-                sb.append(c);
-            } else {
-                sb.append(Character.toUpperCase(c));
-            }
-        }
-        sb.append("_ID");
-        return sb.toString();
-    }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookClubIdAndMemberId(Long bookClubId, Long memberId) {
         String nativeQuery = "(SELECT bc.book_club_id, m.member_id " +
@@ -99,6 +52,177 @@ public class AuthorizationJdbcRepository {
         Map<String, Long> paramSource = Map.of("bookClubId", bookClubId, "memberId", memberId);
 
         return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(BookClub.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookIdAndMemberId(Long bookId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, b.book_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND b.book_id = :bookId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, b.book_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "WHERE b.book_id = :bookId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, b.book_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("bookId", bookId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Book.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByGatheringIdAndMemberId(Long gatheringId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, g.gathering_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN gathering g ON b.book_id = g.book_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND g.gathering_id = :gatheringId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, g.gathering_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN gathering g ON b.book_id = g.book_id " +
+                "WHERE g.gathering_id = :gatheringId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, g.gathering_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN gathering g ON b.book_id = g.book_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("gatheringId", gatheringId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Gathering.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByChapterIdAndMemberId(Long chapterId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, c.chapter_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND c.chapter_id = :chapterId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, c.chapter_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "WHERE c.chapter_id = :chapterId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, c.chapter_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("chapterId", chapterId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Chapter.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByTopicIdAndMemberId(Long topicId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, t.topic_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND t.topic_id = :topicId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, t.topic_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "WHERE t.topic_id = :topicId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, t.topic_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("topicId", topicId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Topic.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookmarkIdAndMemberId(Long bookmarkId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, bm.bookmark_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND bm.bookmark_id = :bookmarkId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, bm.bookmark_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "WHERE bm.bookmark_id = :bookmarkId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, bm.bookmark_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("bookmarkId", bookmarkId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Bookmark.class));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByCommentIdAndMemberId(Long commentId, Long memberId) {
@@ -128,7 +252,7 @@ public class AuthorizationJdbcRepository {
                 "UNION ALL " +
                 "(SELECT bc.book_club_id, m.member_id, cm.comment_id " +
                 "FROM book_club_member bcm " +
-                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
                 "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
                 "INNER JOIN chapter c ON b.book_id = c.book_id " +
                 "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
@@ -141,6 +265,58 @@ public class AuthorizationJdbcRepository {
         Map<String, Long> paramSource = Map.of("commentId", commentId, "memberId", memberId);
 
         return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Comment.class));
+    }
+
+    private RowMapper<BookClubMemberAuthInfo> createAuthRowMapper(Class<?> entity) {
+        return (resultSet, rowNum) -> {
+            Long bookClubId = getLongOrNull(resultSet, "book_club_id");
+            Long memberId = getLongOrNull(resultSet, "member_id");
+            Long entityId = getEntityIdOrNull(resultSet, entity);
+
+            return new BookClubMemberAuthInfo(bookClubId, memberId, entityId);
+        };
+    }
+
+    private Long getLongOrNull(ResultSet resultSet, String columnName) throws SQLException {
+        Long l = resultSet.getLong(columnName);
+
+        if (resultSet.wasNull()) {
+            return null;
+        }
+        return l;
+    }
+
+    private Long getEntityIdOrNull(ResultSet resultSet, Class<?> entity) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        String className = entity.getSimpleName();
+        String columnName = convertClassNameToColumnName(className);
+
+        for (int i = 1; i <= metaData.getColumnCount(); i++) {
+            String metaColumnName = metaData.getColumnName(i);
+
+            if (metaColumnName.equals(columnName) || metaColumnName.equals(columnName.toLowerCase())) {
+                return getLongOrNull(resultSet, columnName);
+            }
+        }
+        return null;
+    }
+
+    private String convertClassNameToColumnName(String className) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(Character.toUpperCase(className.charAt(0)));
+        for (int i = 1; i < className.length(); i++) {
+            char c = className.charAt(i);
+
+            if (Character.isUpperCase(c)) {
+                sb.append('_');
+                sb.append(c);
+            } else {
+                sb.append(Character.toUpperCase(c));
+            }
+        }
+        sb.append("_ID");
+        return sb.toString();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
@@ -10,14 +10,8 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import codesquad.bookkbookk.common.type.EntityType;
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
-import codesquad.bookkbookk.domain.book.data.entity.Book;
-import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
-import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
-import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
-import codesquad.bookkbookk.domain.comment.data.entity.Comment;
-import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
-import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,7 +45,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("bookClubId", bookClubId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(BookClub.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.BOOK_CLUB));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookIdAndMemberId(Long bookId, Long memberId) {
@@ -81,7 +75,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("bookId", bookId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Book.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.BOOK));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByGatheringIdAndMemberId(Long gatheringId, Long memberId) {
@@ -114,7 +108,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("gatheringId", gatheringId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Gathering.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.GATHERING));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByChapterIdAndMemberId(Long chapterId, Long memberId) {
@@ -147,7 +141,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("chapterId", chapterId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Chapter.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.CHAPTER));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByTopicIdAndMemberId(Long topicId, Long memberId) {
@@ -183,7 +177,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("topicId", topicId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Topic.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.TOPIC));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookmarkIdAndMemberId(Long bookmarkId, Long memberId) {
@@ -222,7 +216,7 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("bookmarkId", bookmarkId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Bookmark.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.BOOKMARK));
     }
 
     public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByCommentIdAndMemberId(Long commentId, Long memberId) {
@@ -264,14 +258,14 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("commentId", commentId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Comment.class));
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(EntityType.COMMENT));
     }
 
-    private RowMapper<BookClubMemberAuthInfo> createAuthRowMapper(Class<?> entity) {
+    private RowMapper<BookClubMemberAuthInfo> createAuthRowMapper(EntityType type) {
         return (resultSet, rowNum) -> {
             Long bookClubId = getLongOrNull(resultSet, "book_club_id");
             Long memberId = getLongOrNull(resultSet, "member_id");
-            Long entityId = getEntityIdOrNull(resultSet, entity);
+            Long entityId = getEntityIdOrNull(resultSet, type);
 
             return new BookClubMemberAuthInfo(bookClubId, memberId, entityId);
         };
@@ -286,37 +280,18 @@ public class AuthorizationJdbcRepository {
         return l;
     }
 
-    private Long getEntityIdOrNull(ResultSet resultSet, Class<?> entity) throws SQLException {
+    private Long getEntityIdOrNull(ResultSet resultSet, EntityType type) throws SQLException {
         ResultSetMetaData metaData = resultSet.getMetaData();
-        String className = entity.getSimpleName();
-        String columnName = convertClassNameToColumnName(className);
+        String idColumnName = type.getIdColumnName();
 
         for (int i = 1; i <= metaData.getColumnCount(); i++) {
             String metaColumnName = metaData.getColumnName(i);
 
-            if (metaColumnName.equals(columnName) || metaColumnName.equals(columnName.toLowerCase())) {
-                return getLongOrNull(resultSet, columnName);
+            if (metaColumnName.equals(idColumnName) || metaColumnName.equals(idColumnName.toLowerCase())) {
+                return getLongOrNull(resultSet, idColumnName);
             }
         }
         return null;
-    }
-
-    private String convertClassNameToColumnName(String className) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(Character.toUpperCase(className.charAt(0)));
-        for (int i = 1; i < className.length(); i++) {
-            char c = className.charAt(i);
-
-            if (Character.isUpperCase(c)) {
-                sb.append('_');
-                sb.append(c);
-            } else {
-                sb.append(Character.toUpperCase(c));
-            }
-        }
-        sb.append("_ID");
-        return sb.toString();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
@@ -1,5 +1,8 @@
 package codesquad.bookkbookk.domain.auth.repository;
 
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
@@ -8,6 +11,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,41 +22,74 @@ public class AuthorizationJdbcRepository {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
-    private final RowMapper<BookClubMemberAuthInfo> authRowMapper = (resultSet, rowNum) -> {
-        Long bookClubMemberId = resultSet.getLong("book_club_member_id");
-        if (resultSet.wasNull()) {
-            bookClubMemberId = null;
+    private RowMapper<BookClubMemberAuthInfo> createAuthRowMapper(Class<?> entity) {
+        return (resultSet, rowNum) -> {
+            Long bookClubId = getLongOrNull(resultSet, "book_club_id");
+            Long memberId = getLongOrNull(resultSet, "member_id");
+            Long entityId = getEntityIdOrNull(resultSet, entity);
+
+            return new BookClubMemberAuthInfo(bookClubId, memberId, entityId);
+        };
+    }
+
+    private Long getEntityIdOrNull(ResultSet resultSet, Class<?> entity) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        String className = entity.getSimpleName();
+        String columnName = convertClassNameToColumnName(className);
+
+        for (int i = 1; i <= metaData.getColumnCount(); i++) {
+            String metaColumnName = metaData.getColumnName(i);
+
+            if (metaColumnName.equals(columnName) || metaColumnName.equals(columnName.toLowerCase())) {
+                return getLongOrNull(resultSet, columnName);
+            }
         }
+        return null;
+    }
 
-        Long bookClubId = resultSet.getLong("book_club_id");
+    private Long getLongOrNull(ResultSet resultSet, String columnName) throws SQLException {
+        Long l = resultSet.getLong(columnName);
+
         if (resultSet.wasNull()) {
-            bookClubId = null;
+            return null;
         }
+        return l;
+    }
 
-        Long memberId = resultSet.getLong("member_id");
-        if (resultSet.wasNull()) {
-            memberId = null;
+    private String convertClassNameToColumnName(String className) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(Character.toUpperCase(className.charAt(0)));
+        for (int i = 1; i < className.length(); i++) {
+            char c = className.charAt(i);
+
+            if (Character.isUpperCase(c)) {
+                sb.append('_');
+                sb.append(c);
+            } else {
+                sb.append(Character.toUpperCase(c));
+            }
         }
+        sb.append("_ID");
+        return sb.toString();
+    }
 
-        return new BookClubMemberAuthInfo(bookClubMemberId, bookClubId, memberId);
-    };
-
-    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByMemberIdAndBookClubId(Long bookClubId, Long memberId) {
-        String nativeQuery = "(SELECT m.member_id, bc.book_club_id, bcm.book_club_member_id " +
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByBookClubIdAndMemberId(Long bookClubId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id " +
                 "FROM book_club_member bcm " +
                 "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
                 "INNER JOIN member m ON bcm.member_id = m.member_id " +
                 "WHERE m.member_id = :memberId AND bc.book_club_id = :bookClubId " +
                 "LIMIT 1) " +
                 "UNION ALL " +
-                "(SELECT m.member_id, bc.book_club_id, book_club_member_id " +
+                "(SELECT bc.book_club_id, m.member_id " +
                 "FROM book_club_member bcm " +
                 "INNER JOIN member m ON bcm.member_id = m.member_id " +
                 "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
                 "WHERE bc.book_club_id = :bookClubId " +
                 "LIMIT 1) " +
                 "UNION ALL " +
-                "(SELECT m.member_id, bc.book_club_id, bcm.book_club_member_id " +
+                "(SELECT bc.book_club_id, m.member_id " +
                 "FROM book_club_member bcm " +
                 "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
                 "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
@@ -60,7 +98,49 @@ public class AuthorizationJdbcRepository {
 
         Map<String, Long> paramSource = Map.of("bookClubId", bookClubId, "memberId", memberId);
 
-        return jdbcTemplate.query(nativeQuery, paramSource, authRowMapper);
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(BookClub.class));
+    }
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByCommentIdAndMemberId(Long commentId, Long memberId) {
+        String nativeQuery = "(SELECT bc.book_club_id, m.member_id, cm.comment_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "INNER JOIN comment cm ON bm.bookmark_id = cm.bookmark_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND cm.comment_id = :commentId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, cm.comment_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "INNER JOIN comment cm ON bm.bookmark_id = cm.bookmark_id " +
+                "WHERE cm.comment_id = :commentId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT bc.book_club_id, m.member_id, cm.comment_id " +
+                "FROM book_club_member bcm " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "INNER JOIN book b ON bc.book_club_id = b.book_club_id " +
+                "INNER JOIN chapter c ON b.book_id = c.book_id " +
+                "INNER JOIN topic t ON c.chapter_id = t.chapter_id " +
+                "INNER JOIN bookmark bm ON t.topic_id = bm.topic_id " +
+                "INNER JOIN comment cm ON bm.bookmark_id = cm.bookmark_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("commentId", commentId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, createAuthRowMapper(Comment.class));
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/repository/AuthorizationJdbcRepository.java
@@ -1,0 +1,66 @@
+package codesquad.bookkbookk.domain.auth.repository;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthorizationJdbcRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    private final RowMapper<BookClubMemberAuthInfo> authRowMapper = (resultSet, rowNum) -> {
+        Long bookClubMemberId = resultSet.getLong("book_club_member_id");
+        if (resultSet.wasNull()) {
+            bookClubMemberId = null;
+        }
+
+        Long bookClubId = resultSet.getLong("book_club_id");
+        if (resultSet.wasNull()) {
+            bookClubId = null;
+        }
+
+        Long memberId = resultSet.getLong("member_id");
+        if (resultSet.wasNull()) {
+            memberId = null;
+        }
+
+        return new BookClubMemberAuthInfo(bookClubMemberId, bookClubId, memberId);
+    };
+
+    public List<BookClubMemberAuthInfo> findBookClubMemberAuthsByMemberIdAndBookClubId(Long bookClubId, Long memberId) {
+        String nativeQuery = "(SELECT m.member_id, bc.book_club_id, bcm.book_club_member_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId AND bc.book_club_id = :bookClubId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT m.member_id, bc.book_club_id, book_club_member_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN member m ON bcm.member_id = m.member_id " +
+                "RIGHT JOIN book_club bc ON bcm.book_club_id = bc.book_club_id  " +
+                "WHERE bc.book_club_id = :bookClubId " +
+                "LIMIT 1) " +
+                "UNION ALL " +
+                "(SELECT m.member_id, bc.book_club_id, bcm.book_club_member_id " +
+                "FROM book_club_member bcm " +
+                "INNER JOIN book_club bc ON bcm.book_club_id = bc.book_club_id " +
+                "RIGHT JOIN member m ON bcm.member_id = m.member_id " +
+                "WHERE m.member_id = :memberId " +
+                "LIMIT 1)";
+
+        Map<String, Long> paramSource = Map.of("bookClubId", bookClubId, "memberId", memberId);
+
+        return jdbcTemplate.query(nativeQuery, paramSource, authRowMapper);
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
@@ -14,9 +14,14 @@ import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationJdbcRepository;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationRepository;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,57 +41,44 @@ public class AuthorizationService {
         validateAuthInfos(authInfos, bookClubId, memberId, BookClub.class);
     }
 
-    private void validateAuthInfos(List<BookClubMemberAuthInfo> authInfos, Long entityId, Long memberId, Class<?> entity) {
+    @Transactional(readOnly = true)
+    public void authorizeBookClubMembershipByBookId(Long bookId, Long memberId) {
+        List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
+                .findBookClubMemberAuthsByBookIdAndMemberId(bookId, memberId);
 
-        int infoSize = authInfos.size();
-
-        if (infoSize == 3) return;
-        if (infoSize == 2) throw new MemberNotInBookClubException();
-        if (infoSize == 1) {
-            Long authEntityId = authInfos.get(0).getEntityId();
-            Long authMemberId = authInfos.get(0).getMemberId();
-
-            if (authEntityId == null) throw new EntityNotFountException(entity);
-            if (authMemberId == null) throw new EntityNotFountException(Member.class);
-            if (authEntityId.equals(entityId)) throw new EntityNotFountException(Member.class);
-            if (authMemberId.equals(memberId)) throw new EntityNotFountException(entity);
-        }
-        throw new BookClubAuthorizationFailedException();
+        validateAuthInfos(authInfos, bookId, memberId, Book.class);
     }
 
     @Transactional(readOnly = true)
-    public void authorizeBookClubMembershipByBookId(Long memberId, Long bookId) {
-        if (!authorizationRepository.existsBookClubMemberByMemberIdAndBookId(memberId, bookId)) {
-            throw new MemberNotInBookClubException();
-        }
+    public void authorizeBookClubMembershipByGatheringId(Long gatheringId, Long memberId) {
+        List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
+                .findBookClubMemberAuthsByGatheringIdAndMemberId(gatheringId, memberId);
+
+        validateAuthInfos(authInfos, gatheringId, memberId, Gathering.class);
     }
 
     @Transactional(readOnly = true)
-    public void authorizeBookClubMembershipByGatheringId(Long memberId, Long gatheringId) {
-        if (!authorizationRepository.existsBookClubMemberByMemberIdAndGatheringId(memberId, gatheringId)) {
-            throw new MemberNotInBookClubException();
-        }
+    public void authorizeBookClubMembershipByChapterId(Long chapterId, Long memberId) {
+        List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
+                .findBookClubMemberAuthsByChapterIdAndMemberId(chapterId, memberId);
+
+        validateAuthInfos(authInfos, chapterId, memberId, Chapter.class);
     }
 
     @Transactional(readOnly = true)
-    public void authorizeBookClubMembershipByChapterId(Long memberId, Long chapterId) {
-        if (!authorizationRepository.existsBookClubMemberByMemberIdAndChapterId(memberId, chapterId)) {
-            throw new MemberNotInBookClubException();
-        }
+    public void authorizeBookClubMembershipByTopicId(Long topicId, Long memberId) {
+        List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
+                .findBookClubMemberAuthsByTopicIdAndMemberId(topicId, memberId);
+
+        validateAuthInfos(authInfos, topicId, memberId, Topic.class);
     }
 
     @Transactional(readOnly = true)
-    public void authorizeBookClubMembershipByTopicId(Long memberId, Long topicId) {
-        if (!authorizationRepository.existsBookClubMemberByMemberIdAndTopicId(memberId, topicId)) {
-            throw new MemberNotInBookClubException();
-        }
-    }
+    public void authorizeBookClubMembershipByBookmarkId(Long bookmarkId, Long memberId) {
+        List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
+                .findBookClubMemberAuthsByBookmarkIdAndMemberId(bookmarkId, memberId);
 
-    @Transactional(readOnly = true)
-    public void authorizeBookClubMembershipByBookmarkId(Long memberId, Long bookmarkId) {
-        if (!authorizationRepository.existsBookClubMemberByMemberIdAndBookmarkId(memberId, bookmarkId)) {
-            throw new MemberNotInBookClubException();
-        }
+        validateAuthInfos(authInfos, bookmarkId, memberId, Bookmark.class);
     }
 
     @Transactional(readOnly = true)
@@ -117,6 +109,24 @@ public class AuthorizationService {
         if (!authorizationRepository.existsCommentByIdAndWriterId(commentId, writerId)) {
             throw new MemberIsNotCommentWriterException();
         }
+    }
+
+    private void validateAuthInfos(List<BookClubMemberAuthInfo> authInfos, Long entityId, Long memberId, Class<?> entity) {
+
+        int infoSize = authInfos.size();
+
+        if (infoSize == 3) return;
+        if (infoSize == 2) throw new MemberNotInBookClubException();
+        if (infoSize == 1) {
+            Long authEntityId = authInfos.get(0).getEntityId();
+            Long authMemberId = authInfos.get(0).getMemberId();
+
+            if (authEntityId == null) throw new EntityNotFountException(entity);
+            if (authMemberId == null) throw new EntityNotFountException(Member.class);
+            if (authEntityId.equals(entityId)) throw new EntityNotFountException(Member.class);
+            if (authMemberId.equals(memberId)) throw new EntityNotFountException(entity);
+        }
+        throw new BookClubAuthorizationFailedException();
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
@@ -30,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 public class AuthorizationService {
 
     private final AuthorizationRepository authorizationRepository;
-
     private final AuthorizationJdbcRepository authorizationJdbcRepository;
 
     @Transactional(readOnly = true)

--- a/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/auth/service/AuthorizationService.java
@@ -11,17 +11,10 @@ import codesquad.bookkbookk.common.error.exception.MemberIsNotBookmarkWriterExce
 import codesquad.bookkbookk.common.error.exception.MemberIsNotCommentWriterException;
 import codesquad.bookkbookk.common.error.exception.MemberJoinedBookClubException;
 import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
+import codesquad.bookkbookk.common.type.EntityType;
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationJdbcRepository;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationRepository;
-import codesquad.bookkbookk.domain.book.data.entity.Book;
-import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
-import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
-import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
-import codesquad.bookkbookk.domain.comment.data.entity.Comment;
-import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
-import codesquad.bookkbookk.domain.member.data.entity.Member;
-import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,7 +30,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClubId, memberId);
 
-        validateAuthInfos(authInfos, bookClubId, memberId, BookClub.class);
+        validateAuthInfos(authInfos, bookClubId, memberId, EntityType.BOOK_CLUB);
     }
 
     @Transactional(readOnly = true)
@@ -45,7 +38,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByBookIdAndMemberId(bookId, memberId);
 
-        validateAuthInfos(authInfos, bookId, memberId, Book.class);
+        validateAuthInfos(authInfos, bookId, memberId, EntityType.BOOK);
     }
 
     @Transactional(readOnly = true)
@@ -53,7 +46,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByGatheringIdAndMemberId(gatheringId, memberId);
 
-        validateAuthInfos(authInfos, gatheringId, memberId, Gathering.class);
+        validateAuthInfos(authInfos, gatheringId, memberId, EntityType.GATHERING);
     }
 
     @Transactional(readOnly = true)
@@ -61,7 +54,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByChapterIdAndMemberId(chapterId, memberId);
 
-        validateAuthInfos(authInfos, chapterId, memberId, Chapter.class);
+        validateAuthInfos(authInfos, chapterId, memberId, EntityType.CHAPTER);
     }
 
     @Transactional(readOnly = true)
@@ -69,7 +62,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByTopicIdAndMemberId(topicId, memberId);
 
-        validateAuthInfos(authInfos, topicId, memberId, Topic.class);
+        validateAuthInfos(authInfos, topicId, memberId, EntityType.TOPIC);
     }
 
     @Transactional(readOnly = true)
@@ -77,7 +70,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByBookmarkIdAndMemberId(bookmarkId, memberId);
 
-        validateAuthInfos(authInfos, bookmarkId, memberId, Bookmark.class);
+        validateAuthInfos(authInfos, bookmarkId, memberId, EntityType.BOOKMARK);
     }
 
     @Transactional(readOnly = true)
@@ -85,7 +78,7 @@ public class AuthorizationService {
         List<BookClubMemberAuthInfo> authInfos = authorizationJdbcRepository
                 .findBookClubMemberAuthsByCommentIdAndMemberId(commentId, memberId);
 
-        validateAuthInfos(authInfos, commentId, memberId, Comment.class);
+        validateAuthInfos(authInfos, commentId, memberId, EntityType.COMMENT);
     }
 
 
@@ -110,7 +103,7 @@ public class AuthorizationService {
         }
     }
 
-    private void validateAuthInfos(List<BookClubMemberAuthInfo> authInfos, Long entityId, Long memberId, Class<?> entity) {
+    private void validateAuthInfos(List<BookClubMemberAuthInfo> authInfos, Long entityId, Long memberId, EntityType type) {
 
         int infoSize = authInfos.size();
 
@@ -120,10 +113,10 @@ public class AuthorizationService {
             Long authEntityId = authInfos.get(0).getEntityId();
             Long authMemberId = authInfos.get(0).getMemberId();
 
-            if (authEntityId == null) throw new EntityNotFountException(entity);
-            if (authMemberId == null) throw new EntityNotFountException(Member.class);
-            if (authEntityId.equals(entityId)) throw new EntityNotFountException(Member.class);
-            if (authMemberId.equals(memberId)) throw new EntityNotFountException(entity);
+            if (authEntityId == null) throw new EntityNotFountException(type);
+            if (authMemberId == null) throw new EntityNotFountException(EntityType.MEMBER);
+            if (authEntityId.equals(entityId)) throw new EntityNotFountException(EntityType.MEMBER);
+            if (authMemberId.equals(memberId)) throw new EntityNotFountException(type);
         }
         throw new BookClubAuthorizationFailedException();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/book/service/BookService.java
@@ -39,7 +39,7 @@ public class BookService {
 
     @Transactional
     public CreateBookResponse createBook(Long memberId, CreateBookRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, request.getBookClubId());
+        authorizationService.authorizeBookClubMembershipByBookClubId(request.getBookClubId(), memberId);
 
         BookClub bookclub = bookClubRepository.findById(request.getBookClubId())
                 .orElseThrow(BookClubNotFoundException::new);
@@ -70,7 +70,7 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public ReadBookClubBookResponse readBookClubBooks(Long memberId, Long bookClubId, Pageable pageable) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+        authorizationService.authorizeBookClubMembershipByBookClubId(bookClubId, memberId);
 
         Slice<Book> books = bookRepository.findSliceByBookClubId(bookClubId, pageable);
         return ReadBookClubBookResponse.from(books);
@@ -78,7 +78,7 @@ public class BookService {
 
     @Transactional
     public UpdateBookStatusResponse updateBookStatus(Long memberId, Long bookId, UpdateBookStatusRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
+        authorizationService.authorizeBookClubMembershipByBookId(bookId, memberId);
 
         Book book = bookRepository.findById(bookId).orElseThrow(BookNotFoundException::new);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -95,7 +95,7 @@ public class BookClubService {
 
     @Transactional
     public InvitationUrlResponse createInvitationUrl(Long memberId, CreateInvitationUrlRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, request.getBookClubId());
+        authorizationService.authorizeBookClubMembershipByBookClubId(request.getBookClubId(), memberId);
 
         String invitationCode = String.valueOf(UUID.randomUUID());
         redisService.saveInvitationCode(invitationCode, request.getBookClubId());
@@ -110,7 +110,7 @@ public class BookClubService {
         if (bookClubId == null) throw new InvitationCodeNotSavedException();
         BookClub bookClub = bookClubRepository.findByIdWithBooks(bookClubId).orElseThrow(BookClubNotFoundException::new);
 
-        authorizationService.authorizeBookClubJoin(memberId, bookClub.getId());
+        authorizationService.authorizeBookClubJoin(bookClub.getId(), memberId);
 
         bookClub.addMember(new BookClubMember(bookClub, member));
         bookClub.getBooks().forEach(member::addBook);
@@ -120,7 +120,7 @@ public class BookClubService {
 
     @Transactional(readOnly = true)
     public ReadBookClubDetailResponse readBookClubDetail(Long memberId, Long bookClubId) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+        authorizationService.authorizeBookClubMembershipByBookClubId(bookClubId, memberId);
 
         BookClub bookClub = bookClubRepository.findDetailById(bookClubId).orElseThrow(BookClubNotFoundException::new);
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/service/BookmarkService.java
@@ -43,7 +43,7 @@ public class BookmarkService {
 
     @Transactional
     public void createBookmark(Long memberId, CreateBookmarkRequest createBookmarkRequest) {
-        authorizationService.authorizeBookClubMembershipByTopicId(memberId, createBookmarkRequest.getTopicId());
+        authorizationService.authorizeBookClubMembershipByTopicId(createBookmarkRequest.getTopicId(), memberId);
 
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Topic topic = topicRepository.findById(createBookmarkRequest.getTopicId())
@@ -60,7 +60,7 @@ public class BookmarkService {
 
     @Transactional(readOnly = true)
     public List<ReadBookmarkResponse> readBookmarks(Long memberId, Long topicId) {
-        authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
+        authorizationService.authorizeBookClubMembershipByTopicId(topicId, memberId);
 
         List<Bookmark> bookmarks = bookmarkRepository.findAllByTopicId(topicId);
 
@@ -69,7 +69,7 @@ public class BookmarkService {
 
     @Transactional(readOnly = true)
     public List<ReadBookmarkResponse> readBookmarksWithFilter(Long memberId, Long bookId, BookmarkFilter bookmarkFilter) {
-        authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
+        authorizationService.authorizeBookClubMembershipByBookId(bookId, memberId);
 
         List<Bookmark> bookmarks = bookmarkRepository.findAllByFilter(bookId, bookmarkFilter);
 
@@ -94,7 +94,7 @@ public class BookmarkService {
 
     @Transactional
     public void createBookmarkReaction(Long memberId, Long bookmarkId, CreateBookmarkReactionRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+        authorizationService.authorizeBookClubMembershipByBookmarkId(bookmarkId, memberId);
 
         Reaction reaction = Reaction.of(request.getReactionName());
         if (bookmarkReactionRepository.existsByBookmarkIdAndReactorIdAndReaction(bookmarkId, memberId, reaction)) {
@@ -121,7 +121,7 @@ public class BookmarkService {
 
     @Transactional(readOnly = true)
     public ReadReactionsResponse readBookmarkReactions(Long memberId, Long bookmarkId) {
-        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+        authorizationService.authorizeBookClubMembershipByBookmarkId(bookmarkId, memberId);
 
         return ReadReactionsResponse.fromBookmarkReactions(bookmarkReactionRepository.findAllByBookmarkId(bookmarkId));
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
@@ -38,7 +38,7 @@ public class ChapterService {
 
     @Transactional
     public CreateChapterResponse createChapter(Long memberId, CreateChapterRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookId(memberId, request.getBookId());
+        authorizationService.authorizeBookClubMembershipByBookId(request.getBookId(), memberId);
 
         Book book = bookRepository.findById(request.getBookId()).orElseThrow(BookNotFoundException::new);
         List<CreateChapterRequest.ChapterDataDTO> dataList = request.toEntities(book);
@@ -60,7 +60,7 @@ public class ChapterService {
 
     @Transactional(readOnly = true)
     public List<ReadChapterResponse> readChapters(Long memberId, Long bookId, int chapterStatusId) {
-        authorizationService.authorizeBookClubMembershipByBookId(memberId, bookId);
+        authorizationService.authorizeBookClubMembershipByBookId(bookId, memberId);
 
         Status chapterStatus;
         if (chapterStatusId == ALL_STATUS) {
@@ -74,7 +74,7 @@ public class ChapterService {
 
     @Transactional
     public UpdateChapterResponse updateChapter(Long memberId, Long chapterId, UpdateChapterRequest request) {
-        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+        authorizationService.authorizeBookClubMembershipByChapterId(chapterId, memberId);
 
         Chapter chapter = chapterRepository.findById(chapterId).orElseThrow(ChapterNotFoundException::new);
 
@@ -84,7 +84,7 @@ public class ChapterService {
 
     @Transactional
     public void deleteChapter(Long memberId, Long chapterId) {
-        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+        authorizationService.authorizeBookClubMembershipByChapterId(chapterId, memberId);
 
         chapterRepository.deleteById(chapterId);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/service/CommentService.java
@@ -42,7 +42,7 @@ public class CommentService {
 
     @Transactional
     public void createComment(Long memberId, CreateCommentRequest createCommentRequest) {
-        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, createCommentRequest.getBookmarkId());
+        authorizationService.authorizeBookClubMembershipByBookmarkId(createCommentRequest.getBookmarkId(), memberId);
 
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Bookmark bookmark = bookmarkRepository.findById(createCommentRequest.getBookmarkId())
@@ -70,7 +70,7 @@ public class CommentService {
 
     @Transactional
     public void createCommentReaction(Long memberId, Long commentId, CreateCommentReactionRequest request) {
-        authorizationService.authorizeBookClubMembershipByCommentId(memberId, commentId);
+        authorizationService.authorizeBookClubMembershipByCommentId(commentId, memberId);
 
         Reaction reaction = Reaction.of(request.getReactionName());
         if (commentReactionRepository.existsByCommentIdAndReactorIdAndReaction(commentId, memberId, reaction)) {
@@ -97,14 +97,14 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<ReadCommentResponse> readComments(Long memberId, Long bookmarkId) {
-        authorizationService.authorizeBookClubMembershipByBookmarkId(memberId, bookmarkId);
+        authorizationService.authorizeBookClubMembershipByBookmarkId(bookmarkId, memberId);
 
         return ReadCommentResponse.from(commentRepository.findAllByBookmarkId(bookmarkId));
     }
 
     @Transactional(readOnly = true)
     public ReadReactionsResponse readCommentReactions(Long memberId, Long commentId) {
-        authorizationService.authorizeBookClubMembershipByCommentId(memberId, commentId);
+        authorizationService.authorizeBookClubMembershipByCommentId(commentId, memberId);
 
         return ReadReactionsResponse.fromCommentReactions(commentReactionRepository.findAllByCommentId(commentId));
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/gathering/service/GatheringService.java
@@ -36,7 +36,7 @@ public class GatheringService {
 
     @Transactional
     public void createGathering(Long memberId, Long bookClubId, CreateGatheringsRequest request) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+        authorizationService.authorizeBookClubMembershipByBookClubId(bookClubId, memberId);
 
         Book book = bookRepository.findById(request.getBookId()).orElseThrow(BookNotFoundException::new);
         BookClub bookClub = bookClubRepository.findById(bookClubId).orElseThrow(BookClubNotFoundException::new);
@@ -52,14 +52,14 @@ public class GatheringService {
 
     @Transactional(readOnly = true)
     public List<ReadGatheringResponse> readGatherings(Long memberId, Long bookClubId) {
-        authorizationService.authorizeBookClubMembershipByBookClubId(memberId, bookClubId);
+        authorizationService.authorizeBookClubMembershipByBookClubId(bookClubId, memberId);
 
         return ReadGatheringResponse.from(gatheringRepository.findAllByBookClubId(bookClubId));
     }
 
     @Transactional
     public UpdateGatheringResponse updateGathering(Long memberId, Long gatheringId, UpdateGatheringRequest request) {
-        authorizationService.authorizeBookClubMembershipByGatheringId(memberId, gatheringId);
+        authorizationService.authorizeBookClubMembershipByGatheringId(gatheringId, memberId);
 
         Gathering gathering = gatheringRepository.findById(gatheringId).orElseThrow(GatheringNotFoundException::new);
 
@@ -69,7 +69,7 @@ public class GatheringService {
 
     @Transactional
     public void deleteGathering(Long memberId, Long gatheringId) {
-        authorizationService.authorizeBookClubMembershipByGatheringId(memberId, gatheringId);
+        authorizationService.authorizeBookClubMembershipByGatheringId(gatheringId, memberId);
 
         gatheringRepository.deleteById(gatheringId);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -45,7 +45,7 @@ public class BookClubMember {
 
     public BookClubMember(BookClub bookClub, Member member) {
         this.bookClub = bookClub;
-        if (bookClub != null) this.bookClubId = getBookClubId();
+        if (bookClub != null) this.bookClubId = bookClub.getId();
         this.member = member;
         if (member != null) this.memberId = member.getId();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/service/TopicService.java
@@ -30,7 +30,7 @@ public class TopicService {
 
     @Transactional
     public CreateTopicResponse createTopic(Long memberId, CreateTopicRequest request) {
-        authorizationService.authorizeBookClubMembershipByChapterId(memberId, request.getChapterId());
+        authorizationService.authorizeBookClubMembershipByChapterId(request.getChapterId(), memberId);
 
         Chapter chapter = chapterRepository.findById(request.getChapterId())
                 .orElseThrow(ChapterNotFoundException::new);
@@ -42,7 +42,7 @@ public class TopicService {
 
     @Transactional(readOnly = true)
     public List<ReadTopicResponse> readTopicLIst(Long memberId, Long chapterId) {
-        authorizationService.authorizeBookClubMembershipByChapterId(memberId, chapterId);
+        authorizationService.authorizeBookClubMembershipByChapterId(chapterId, memberId);
 
         List<Topic> topicList = topicRepository.findByChapterId(chapterId);
 
@@ -51,7 +51,7 @@ public class TopicService {
 
     @Transactional
     public void updateTitle(Long memberId, Long topicId, UpdateTopicTitleRequest request) {
-        authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
+        authorizationService.authorizeBookClubMembershipByTopicId(topicId, memberId);
 
         Topic topic = topicRepository.findById(topicId).orElseThrow(TopicNotFoundException::new);
 
@@ -59,7 +59,7 @@ public class TopicService {
     }
 
     public void deleteTopic(Long memberId, Long topicId) {
-        authorizationService.authorizeBookClubMembershipByTopicId(memberId, topicId);
+        authorizationService.authorizeBookClubMembershipByTopicId(topicId, memberId);
 
         topicRepository.deleteById(topicId);
     }

--- a/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthNTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthNTest.java
@@ -19,12 +19,14 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
-public class AuthTest extends IntegrationTest {
+public class AuthNTest extends IntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private JwtProvider jwtProvider;
+
     @Autowired
     private JwtProperties jwtProperties;
 

--- a/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthTest.java
@@ -1,0 +1,140 @@
+package codesquad.bookkbookk.integration.scenario;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import codesquad.bookkbookk.common.error.exception.BookClubNotFoundException;
+import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
+import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
+import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.util.IntegrationTest;
+import codesquad.bookkbookk.util.TestDataFactory;
+
+public class AuthTest extends IntegrationTest {
+
+    @Autowired
+    private AuthorizationService authorizationService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookClubRepository bookClubRepository;
+
+    @Autowired
+    private BookClubMemberRepository bookClubMemberRepository;
+
+    @Test
+    @DisplayName("BookClubId로 BookClub 접근을 인가한다.")
+    void authorizeBookClubMembershipByBookClubId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("매핑 엔티티가 만들어 지지 않은 BookClub의 Id로 BookClub 인가를 요청하면 예외가 발생한다.")
+    void authorizeBookClubMembershipByUnmappedBookClubId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), member.getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
+    }
+
+    @Test
+    @DisplayName("저장되지 않은 BookClub의 Id로 BookClub 인가를 요청하면 예외가 발생한다.")
+    void authorizeBookClubMembershipByUnsavedBookClubId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(1L, member.getId())
+        ).isInstanceOf(BookClubNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("저장되지 않은 Member의 Id로 BookClub 인가를 요청하면 예외가 발생한다.")
+    void authorizeBookClubMembershipByUnsavedMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), member.getId() + 1)
+        ).isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("많은 BookClub에 참여한 Member Id로 인가한다.")
+    void authorizeBookClubMembershipByManyJoinedMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        List<BookClub> bookClubs = TestDataFactory.createBookClubs(5, member);
+        bookClubRepository.saveAll(bookClubs);
+
+        List<BookClubMember> bookClubMembers = TestDataFactory.createBookClubMembers(bookClubs, member);
+        bookClubMemberRepository.saveAll(bookClubMembers);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClubs.get(2).getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("많은 Member가 참여한 BookClub Id로 인가한다.")
+    void authorizeBookClubMembershipByManyJoinedBookClubId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(5);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        List<BookClubMember> bookClubMembers = TestDataFactory.createBookClubMembers(bookClub, members);
+        bookClubMemberRepository.saveAll(bookClubMembers);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), members.get(2).getId())
+        ).doesNotThrowAnyException();
+    }
+
+}

--- a/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/integration/scenario/AuthTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import codesquad.bookkbookk.common.error.exception.BookClubNotFoundException;
-import codesquad.bookkbookk.common.error.exception.MemberNotFoundException;
+import codesquad.bookkbookk.common.error.exception.EntityNotFountException;
 import codesquad.bookkbookk.common.error.exception.MemberNotInBookClubException;
 import codesquad.bookkbookk.domain.auth.service.AuthorizationService;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
@@ -19,6 +18,7 @@ import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
@@ -89,7 +89,7 @@ public class AuthTest extends IntegrationTest {
         // when & then
         assertThatThrownBy(
                 () -> authorizationService.authorizeBookClubMembershipByBookClubId(1L, member.getId())
-        ).isInstanceOf(BookClubNotFoundException.class);
+        ).isInstanceOf(EntityNotFountException.class);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class AuthTest extends IntegrationTest {
         // when & then
         assertThatThrownBy(
                 () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), member.getId() + 1)
-        ).isInstanceOf(MemberNotFoundException.class);
+        ).isInstanceOf(EntityNotFountException.class);
     }
 
     @Test
@@ -144,6 +144,254 @@ public class AuthTest extends IntegrationTest {
         assertThatCode(
                 () -> authorizationService.authorizeBookClubMembershipByBookClubId(bookClub.getId(), members.get(2).getId())
         ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Book Id와 Member Id로 Book Club 접근을 인가한다.")
+    void authorizeBookClubMembershipByBookIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByBookId(book.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Book Id와 Member Id로 Book Club 인가가 실패한다.")
+    void denyBookClubAuthorizationByBookIdAndMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByBookId(book.getId(), members.get(1).getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
+    }
+
+    @Test
+    @DisplayName("Gathering Id와 Member Id로 Book Club 접근을 인가한다.")
+    void authorizeBookClubMembershipByGatheringIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Gathering gathering = TestDataFactory.createGathering(book);
+        book.addGathering(gathering);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByGatheringId(gathering.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Gathering Id와 Member Id로 Book Club 인가가 실패한다.")
+    void denyBookClubAuthorizationByGatheringIdAndMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Gathering gathering = TestDataFactory.createGathering(book);
+        book.addGathering(gathering);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByGatheringId(gathering.getId(), members.get(1).getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
+    }
+
+    @Test
+    @DisplayName("Chapter Id와 Member Id로 Book Club 접근을 인가한다.")
+    void authorizeBookClubMembershipByChapterIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByChapterId(chapter.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Chapter Id와 Member Id로 Book Club 인가가 실패한다.")
+    void denyBookClubAuthorizationByChapterIdAndMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByChapterId(chapter.getId(), members.get(1).getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
+    }
+
+    @Test
+    @DisplayName("Topic Id와 Member Id로 Book Club 접근을 인가한다.")
+    void authorizeBookClubMembershipByTopicIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByTopicId(topic.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Topic Id와 Member Id로 Book Club 인가가 실패한다.")
+    void denyBookClubAuthorizationByTopicIdAndMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByTopicId(topic.getId(), members.get(1).getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
+    }
+
+    @Test
+    @DisplayName("Bookmark Id와 Member Id로 Book Club 접근을 인가한다.")
+    void authorizeBookClubMembershipByBookmarkIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(member, topic);
+        topic.addBookmark(bookmark);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatCode(
+                () -> authorizationService.authorizeBookClubMembershipByBookmarkId(bookmark.getId(), member.getId())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Bookmark Id와 Member Id로 Book Club 인가가 실패한다.")
+    void denyBookClubAuthorizationByBookmarkIdAndMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(members.get(0), topic);
+        topic.addBookmark(bookmark);
+        bookRepository.save(book);
+
+        // when & then
+        assertThatThrownBy(
+                () -> authorizationService.authorizeBookClubMembershipByBookmarkId(bookmark.getId(), members.get(1).getId())
+        ).isInstanceOf(MemberNotInBookClubException.class);
     }
 
     @Test

--- a/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
@@ -16,12 +16,18 @@ import org.springframework.test.context.ActiveProfiles;
 import codesquad.bookkbookk.common.config.QueryDslConfig;
 import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationJdbcRepository;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 import codesquad.bookkbookk.util.DatabaseCleaner;
 import codesquad.bookkbookk.util.TestDataFactory;
 
@@ -42,6 +48,9 @@ public class AuthorizationJdbcRepositoryTest {
 
     @Autowired
     private BookClubMemberRepository bookClubMemberRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
 
     @Autowired
     private DatabaseCleaner databaseCleaner;
@@ -66,7 +75,7 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId());
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClub.getId(), member.getId());
 
         // then
         assertThat(authInfos).hasSize(3);
@@ -84,7 +93,7 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId());
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClub.getId(), member.getId());
 
         // then
         assertThat(authInfos).hasSize(2);
@@ -102,7 +111,7 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId() + 1);
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClub.getId(), member.getId() + 1);
 
         // then
         assertThat(authInfos).hasSize(1);
@@ -117,7 +126,7 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(1L, member.getId());
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(1L, member.getId());
 
         // then
         assertThat(authInfos).hasSize(1);
@@ -138,7 +147,7 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClubs.get(2).getId(), member.getId());
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClubs.get(2).getId(), member.getId());
 
         // then
         assertThat(authInfos).hasSize(3);
@@ -159,10 +168,76 @@ public class AuthorizationJdbcRepositoryTest {
 
         // when
         List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
-                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), members.get(2).getId());
+                .findBookClubMemberAuthsByBookClubIdAndMemberId(bookClub.getId(), members.get(2).getId());
 
         // then
         assertThat(authInfos).hasSize(3);
     }
+
+    @Test
+    @DisplayName("Comment Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByCommentId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(member, topic);
+        topic.addBookmark(bookmark);
+        Comment comment = TestDataFactory.createComment(bookmark, member);
+        bookmark.addComment(comment);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByCommentIdAndMemberId(comment.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 Comment Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByCommentIdAndNotParticipatingMember() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(members.get(0), topic);
+        topic.addBookmark(bookmark);
+        Comment comment = TestDataFactory.createComment(bookmark, members.get(0));
+        bookmark.addComment(comment);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByCommentIdAndMemberId(comment.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
 
 }

--- a/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
@@ -1,0 +1,168 @@
+package codesquad.bookkbookk.unit;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import codesquad.bookkbookk.common.config.QueryDslConfig;
+import codesquad.bookkbookk.domain.auth.data.dto.BookClubMemberAuthInfo;
+import codesquad.bookkbookk.domain.auth.repository.AuthorizationJdbcRepository;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.util.DatabaseCleaner;
+import codesquad.bookkbookk.util.TestDataFactory;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({AuthorizationJdbcRepository.class, DatabaseCleaner.class, QueryDslConfig.class})
+public class AuthorizationJdbcRepositoryTest {
+
+    @Autowired
+    private AuthorizationJdbcRepository authorizationCustomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookClubRepository bookClubRepository;
+
+    @Autowired
+    private BookClubMemberRepository bookClubMemberRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    public void cleanUp() {
+        databaseCleaner.execute();
+    }
+
+    @Test
+    @DisplayName("Member와 BookClub이 저장되어 있고 매핑되어 있다면 AuthInfos 크기가 3이다.")
+    void mappedBookClubMemberAuthInfosSizeIs3() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Member와 BookClub이 저장되어 있으나 매핑되지 않았다면 AuthInfos 크기가 2이다.")
+    void unmappedBookClubMemberAuthInfosSizeIs2() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("BookClub이 저장되어 있고 Member가 저장 안된 AuthInfos 크기는 1이다.")
+    void unsavedBookClubAuthInfosSizeIs1() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), member.getId() + 1);
+
+        // then
+        assertThat(authInfos).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("BookClub이 저장되어 있지 않고 Member가 저장된 AuthInfos 크기는 1이다.")
+    void unsavedMemberAuthInfosSizeIs1() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(1L, member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Member가 많은 BookClub에 속해 있어도 AuthInfos 크기에는 영향을 주지 않는다")
+    void memberJoiningManyBookClubsDoesntAffectAuthInfosSize() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        List<BookClub> bookClubs = TestDataFactory.createBookClubs(5, member);
+        bookClubRepository.saveAll(bookClubs);
+
+        List<BookClubMember> bookClubMembers = TestDataFactory.createBookClubMembers(bookClubs, member);
+        bookClubMemberRepository.saveAll(bookClubMembers);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClubs.get(2).getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("BookClub에 많은 Member가 속해 있어도 AuthInfos 크기에는 영향을 주지 않는다")
+    void bookClubHasManyMembersDoesntAffectAuthInfosSize() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(5);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        List<BookClubMember> bookClubMembers = TestDataFactory.createBookClubMembers(bookClub, members);
+        bookClubMemberRepository.saveAll(bookClubMembers);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByMemberIdAndBookClubId(bookClub.getId(), members.get(2).getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+    }
+
+}

--- a/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationJdbcRepositoryTest.java
@@ -23,6 +23,7 @@ import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
+import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
@@ -175,8 +176,281 @@ public class AuthorizationJdbcRepositoryTest {
     }
 
     @Test
+    @DisplayName("Chapter Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByChapterIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByChapterIdAndMemberId(chapter.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 Chapter Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByChapterIdAndNotParticipatingMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByChapterIdAndMemberId(chapter.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Book Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByBookIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByBookIdAndMemberId(book.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 BookId Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByBookIdAndNotParticipatingMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByBookIdAndMemberId(book.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Gathering Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByGatheringIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Gathering gathering = TestDataFactory.createGathering(book);
+        book.addGathering(gathering);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByGatheringIdAndMemberId(gathering.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 Gathering Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByGatheringIdAndNotParticipatingMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Gathering gathering = TestDataFactory.createGathering(book);
+        book.addGathering(gathering);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByGatheringIdAndMemberId(gathering.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Topic Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByTopicIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByTopicIdAndMemberId(topic.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 Topic Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByTopicIdAndNotParticipatingMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByTopicIdAndMemberId(topic.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Bookmark Id와 Member Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByBookmarkIdAndMemberId() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, member);
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(member, topic);
+        topic.addBookmark(bookmark);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByBookmarkIdAndMemberId(bookmark.getId(), member.getId());
+
+        // then
+        assertThat(authInfos).hasSize(3);
+        assertThat(authInfos.get(0).getEntityId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BookClub에 속하지 않은 Member가 Bookmark Id로 AuthInfos를 가져온다.")
+    void findAuthInfosByBookmarkIdAndNotParticipatingMemberId() {
+        // given
+        List<Member> members = TestDataFactory.createMembers(2);
+        memberRepository.saveAll(members);
+
+        BookClub bookClub = TestDataFactory.createBookClub(members.get(0));
+        bookClubRepository.save(bookClub);
+
+        BookClubMember bookClubMember = new BookClubMember(bookClub, members.get(0));
+        bookClubMemberRepository.save(bookClubMember);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        Chapter chapter = TestDataFactory.createChapter(book);
+        book.addChapter(chapter);
+        Topic topic = TestDataFactory.createTopic(chapter);
+        chapter.addTopic(topic);
+        Bookmark bookmark = TestDataFactory.createBookmark(members.get(0), topic);
+        topic.addBookmark(bookmark);
+        bookRepository.save(book);
+
+        // when
+        List<BookClubMemberAuthInfo> authInfos = authorizationCustomRepository
+                .findBookClubMemberAuthsByBookmarkIdAndMemberId(bookmark.getId(), members.get(1).getId());
+
+        // then
+        assertThat(authInfos).hasSize(2);
+    }
+
+    @Test
     @DisplayName("Comment Id와 Member Id로 AuthInfos를 가져온다.")
-    void findAuthInfosByCommentId() {
+    void findAuthInfosByCommentIdAndMemberId() {
         // given
         Member member = TestDataFactory.createMember();
         memberRepository.save(member);
@@ -209,7 +483,7 @@ public class AuthorizationJdbcRepositoryTest {
 
     @Test
     @DisplayName("BookClub에 속하지 않은 Member가 Comment Id로 AuthInfos를 가져온다.")
-    void findAuthInfosByCommentIdAndNotParticipatingMember() {
+    void findAuthInfosByCommentIdAndNotParticipatingMemberId() {
         // given
         List<Member> members = TestDataFactory.createMembers(2);
         memberRepository.saveAll(members);

--- a/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/AuthorizationRepositoryTest.java
@@ -6,44 +6,44 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import codesquad.bookkbookk.util.IntegrationTest;
 import codesquad.bookkbookk.domain.auth.repository.AuthorizationRepository;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.book.repository.BookRepository;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
-import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
-import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.mapping.repository.BookClubMemberRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 import codesquad.bookkbookk.domain.topic.repository.TopicRepository;
+import codesquad.bookkbookk.util.IntegrationTest;
 import codesquad.bookkbookk.util.TestDataFactory;
 
 public class AuthorizationRepositoryTest extends IntegrationTest {
 
     @Autowired
     private AuthorizationRepository authorizationRepository;
+
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private BookClubRepository bookClubRepository;
+
     @Autowired
     private BookClubMemberRepository bookClubMemberRepository;
+
     @Autowired
     private BookRepository bookRepository;
+
     @Autowired
     private ChapterRepository chapterRepository;
+
     @Autowired
     private TopicRepository topicRepository;
-    @Autowired
-    private BookmarkRepository bookmarkRepository;
-    @Autowired
-    private CommentRepository commentRepository;
 
     @Test
     @DisplayName("북클럽 멤버가 저장되었을 떄 멤버의 아이디와 북클럽 아이디로 조회에 성공한다.")

--- a/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
+++ b/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
@@ -57,13 +57,13 @@ public class TestDataFactory {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public static List<BookClubMember> createBookClubMemberS(List<BookClub> bookClubs, Member member) {
+    public static List<BookClubMember> createBookClubMembers(List<BookClub> bookClubs, Member member) {
         return bookClubs.stream()
                 .map(bookClub -> new BookClubMember(bookClub, member))
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public static List<BookClubMember> createBookClubMemberS(BookClub bookClub, List<Member> members) {
+    public static List<BookClubMember> createBookClubMembers(BookClub bookClub, List<Member> members) {
         return members.stream()
                 .map(member -> new BookClubMember(bookClub, member))
                 .collect(Collectors.toUnmodifiableList());

--- a/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
+++ b/be/src/test/java/codesquad/bookkbookk/util/TestDataFactory.java
@@ -13,6 +13,7 @@ import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 import codesquad.bookkbookk.domain.gathering.data.entity.Gathering;
+import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
@@ -53,6 +54,18 @@ public class TestDataFactory {
                         .name("name " + number)
                         .profileImageUrl("image.url " + number)
                         .build())
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public static List<BookClubMember> createBookClubMemberS(List<BookClub> bookClubs, Member member) {
+        return bookClubs.stream()
+                .map(bookClub -> new BookClubMember(bookClub, member))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public static List<BookClubMember> createBookClubMemberS(BookClub bookClub, List<Member> members) {
+        return members.stream()
+                .map(member -> new BookClubMember(bookClub, member))
                 .collect(Collectors.toUnmodifiableList());
     }
 


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- 인가 기능을 보완하여 Entity의 유무까지 확인합니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 엔티티가 있는지 확인하고 매핑 엔티티가 있는지 확인 하는 것이 인가 기능이라고 생각합니다. 
- 인가를 처리할떄 필수적을 3번의 쿼리가 날라가야하는데 이를 한번의 쿼리로 처리했습니다.(Right Join 활용)
- 세번의 쿼리의 결과를 합쳐야해서 `UNION ALL`을 썼는데, `JPQL`에서는 이를 지원하지 않아 `JdbcTemplate`를 활용하여 쿼리를 날립니다.
- `RowMapper`를 여러 메소드에서 쓸 수 있도록 고려했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
