### PR TITLE
[BE] `ReadBookClubDetailResponse` 추상 클래스로 리팩토링 하기

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
@@ -4,44 +4,48 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
-import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse{
+public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse {
 
+    private final Long id;
+    private final String name;
+    private final BookClubStatus status;
+    private final String profileImgUrl;
+    private final Instant createdTime;
+    private final ReadBookClubLastBook lastBook;
+    private final List<ReadBookClubMember> members;
     private final Instant closedTime;
 
     @Builder
     private ClosedBookClubDetailResponse(Long id, String name, BookClubStatus status, String profileImgUrl,
-                                         Instant createdTime, ReadBookClubLastBook readBookClubLastBook,
-                                         List<ReadBookClubMember> readBookClubMembers,
-                                         Instant closedTime) {
-        super(id, name, status, profileImgUrl, createdTime, readBookClubLastBook, readBookClubMembers);
+                                         Instant createdTime, ReadBookClubLastBook lastBook, List<ReadBookClubMember> members, Instant closedTime) {
+
+        this.id = id;
+        this.name = name;
+        this.status = status;
+        this.profileImgUrl = profileImgUrl;
+        this.createdTime = createdTime;
+        this.lastBook = lastBook;
+        this.members = members;
         this.closedTime = closedTime;
     }
 
     public static ClosedBookClubDetailResponse from(BookClub bookClub) {
-        Book lastBook;
-        if (bookClub.getBooks().isEmpty()) {
-            lastBook = null;
-        } else lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
-        List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
-
         return ClosedBookClubDetailResponse.builder()
                 .id(bookClub.getId())
                 .name(bookClub.getName())
                 .status(bookClub.getStatus())
                 .profileImgUrl(bookClub.getProfileImageUrl())
                 .createdTime(bookClub.getCreatedTime())
-                .readBookClubLastBook(ReadBookClubLastBook.from(lastBook))
-                .readBookClubMembers(ReadBookClubMember.from(members))
+                .lastBook(ReadBookClubLastBook.from(bookClub.getBooks()))
+                .members(ReadBookClubMember.from(BookClubMember.toMembers(bookClub.getBookClubMembers())))
                 .closedTime(bookClub.getClosedTime())
                 .build();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ClosedBookClubDetailResponse.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
-import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -45,7 +44,7 @@ public class ClosedBookClubDetailResponse extends ReadBookClubDetailResponse {
                 .profileImgUrl(bookClub.getProfileImageUrl())
                 .createdTime(bookClub.getCreatedTime())
                 .lastBook(ReadBookClubLastBook.from(bookClub.getBooks()))
-                .members(ReadBookClubMember.from(BookClubMember.toMembers(bookClub.getBookClubMembers())))
+                .members(ReadBookClubMember.from(bookClub.getMembers()))
                 .closedTime(bookClub.getClosedTime())
                 .build();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
@@ -4,11 +4,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
-import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -16,32 +14,37 @@ import lombok.Getter;
 @Getter
 public class OpenBookClubDetailResponse extends ReadBookClubDetailResponse{
 
+    private final Long id;
+    private final String name;
+    private final BookClubStatus status;
+    private final String profileImgUrl;
+    private final Instant createdTime;
+    private final ReadBookClubLastBook lastBook;
+    private final List<ReadBookClubMember> members;
     private final Instant upcomingGatheringDate;
 
     @Builder
     private OpenBookClubDetailResponse(Long id, String name, BookClubStatus status, String profileImgUrl,
-                                       Instant createdTime, ReadBookClubDetailResponse.ReadBookClubLastBook readBookClubLastBook,
-                                       List<ReadBookClubDetailResponse.ReadBookClubMember> readBookClubMembers,
-                                       Instant upcomingGatheringDate) {
-        super(id, name, status, profileImgUrl, createdTime, readBookClubLastBook, readBookClubMembers);
+                                      Instant createdTime, ReadBookClubLastBook lastBook, List<ReadBookClubMember> members, Instant upcomingGatheringDate) {
+        this.id = id;
+        this.name = name;
+        this.status = status;
+        this.profileImgUrl = profileImgUrl;
+        this.createdTime = createdTime;
+        this.lastBook = lastBook;
+        this.members = members;
         this.upcomingGatheringDate = upcomingGatheringDate;
     }
 
     public static OpenBookClubDetailResponse from(BookClub bookClub) {
-        Book lastBook;
-        if (bookClub.getBooks().isEmpty()) {
-            lastBook = null;
-        } else lastBook = bookClub.getBooks().get(bookClub.getBooks().size() - 1);
-        List<Member> members = BookClubMember.toMembers(bookClub.getBookClubMembers());
-
         return OpenBookClubDetailResponse.builder()
                 .id(bookClub.getId())
                 .name(bookClub.getName())
                 .status(bookClub.getStatus())
                 .profileImgUrl(bookClub.getProfileImageUrl())
                 .createdTime(bookClub.getCreatedTime())
-                .readBookClubLastBook(ReadBookClubLastBook.from(lastBook))
-                .readBookClubMembers(ReadBookClubMember.from(members))
+                .lastBook(ReadBookClubLastBook.from(bookClub.getBooks()))
+                .members(ReadBookClubMember.from(BookClubMember.toMembers(bookClub.getBookClubMembers())))
                 .upcomingGatheringDate(bookClub.getUpcomingGatheringTime())
                 .build();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/OpenBookClubDetailResponse.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
-import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -44,7 +43,7 @@ public class OpenBookClubDetailResponse extends ReadBookClubDetailResponse{
                 .profileImgUrl(bookClub.getProfileImageUrl())
                 .createdTime(bookClub.getCreatedTime())
                 .lastBook(ReadBookClubLastBook.from(bookClub.getBooks()))
-                .members(ReadBookClubMember.from(BookClubMember.toMembers(bookClub.getBookClubMembers())))
+                .members(ReadBookClubMember.from(bookClub.getMembers()))
                 .upcomingGatheringDate(bookClub.getUpcomingGatheringTime())
                 .build();
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/dto/ReadBookClubDetailResponse.java
@@ -1,37 +1,26 @@
 package codesquad.bookkbookk.domain.bookclub.data.dto;
 
-import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import codesquad.bookkbookk.domain.book.data.entity.Book;
-import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-public class ReadBookClubDetailResponse {
+public abstract class ReadBookClubDetailResponse {
 
-    private final Long id;
-    private final String name;
-    private final BookClubStatus status;
-    private final String profileImgUrl;
-    private final Instant createdTime;
-    private final ReadBookClubLastBook lastBook;
-    private final List<ReadBookClubMember> members;
+    public static List<ReadBookClubDetailResponse> from(List<BookClub> bookClubs) {
+        return bookClubs.stream()
+                .map(ReadBookClubDetailResponse::from)
+                .collect(Collectors.toUnmodifiableList());
+    }
 
-    public ReadBookClubDetailResponse(Long id, String name, BookClubStatus status, String profileImgUrl,
-                                      Instant createdTime, ReadBookClubLastBook readBookClubLastBook,
-                                      List<ReadBookClubMember> members) {
-        this.id = id;
-        this.name = name;
-        this.status = status;
-        this.profileImgUrl = profileImgUrl;
-        this.createdTime = createdTime;
-        this.lastBook = readBookClubLastBook;
-        this.members = members;
+    public static ReadBookClubDetailResponse from(BookClub bookClub) {
+        return bookClub.getStatus().from(bookClub);
     }
 
     @Getter
@@ -45,11 +34,11 @@ public class ReadBookClubDetailResponse {
             this.author = author;
         }
 
-        protected static ReadBookClubLastBook from(Book book) {
-            if (book == null) {
-                return null;
-            }
-            return new ReadBookClubLastBook(book.getTitle(), book.getAuthor());
+        protected static ReadBookClubLastBook from(List<Book> books) {
+            return books.stream()
+                    .max(Comparator.comparingLong(Book::getId))
+                    .map(book -> new ReadBookClubLastBook(book.getTitle(), book.getAuthor()))
+                    .orElse(null);
         }
 
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/entity/BookClub.java
@@ -3,6 +3,7 @@ package codesquad.bookkbookk.domain.bookclub.data.entity;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -20,6 +21,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.bookclub.data.type.BookClubStatus;
 import codesquad.bookkbookk.domain.mapping.entity.BookClubMember;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -85,6 +87,12 @@ public class BookClub {
         if (upcomingGatheringTime == null || upcomingGatheringTime.isAfter(gatheringTime)) {
             upcomingGatheringTime = gatheringTime;
         }
+    }
+
+    public List<Member> getMembers() {
+        return bookClubMembers.stream()
+                .map(BookClubMember::getMember)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     public void close() {

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/data/type/BookClubStatus.java
@@ -12,7 +12,7 @@ public enum BookClubStatus {
 
     OPEN {
         @Override
-        public OpenBookClubDetailResponse from(BookClub bookClub) {
+        public ReadBookClubDetailResponse from(BookClub bookClub) {
             return OpenBookClubDetailResponse.from(bookClub);
         }
 
@@ -23,7 +23,7 @@ public enum BookClubStatus {
     },
     CLOSED {
         @Override
-        public ClosedBookClubDetailResponse from(BookClub bookClub) {
+        public ReadBookClubDetailResponse from(BookClub bookClub) {
             return ClosedBookClubDetailResponse.from(bookClub);
         }
 

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -2,7 +2,6 @@ package codesquad.bookkbookk.domain.bookclub.service;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,9 +80,9 @@ public class BookClubService {
             status = BookClubStatus.of(statusName);
         }
 
-        return bookClubRepository.findAllByMemberIdAndStatus(memberId, status).stream()
-                .map(bookClub -> bookClub.getStatus().from(bookClub))
-                .collect(Collectors.toUnmodifiableList());
+        List<BookClub> bookClubs = bookClubRepository.findAllByMemberIdAndStatus(memberId, status);
+
+        return ReadBookClubDetailResponse.from(bookClubs);
     }
 
     @Transactional

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -116,7 +116,7 @@ public class BookClubService {
 
         BookClub bookClub = bookClubRepository.findDetailById(bookClubId).orElseThrow(BookClubNotFoundException::new);
 
-        return bookClub.getStatus().from(bookClub);
+        return ReadBookClubDetailResponse.from(bookClub);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookclub/service/BookClubService.java
@@ -73,12 +73,7 @@ public class BookClubService {
 
     @Transactional(readOnly = true)
     public List<ReadBookClubDetailResponse> readBookClubs(Long memberId, String statusName) {
-        BookClubStatus status;
-        if (statusName.equals(STATUS_ALL)) {
-            status = null;
-        } else {
-            status = BookClubStatus.of(statusName);
-        }
+        BookClubStatus status = getBookClubStatusOf(statusName);
 
         List<BookClub> bookClubs = bookClubRepository.findAllByMemberIdAndStatus(memberId, status);
 
@@ -117,6 +112,13 @@ public class BookClubService {
         BookClub bookClub = bookClubRepository.findDetailById(bookClubId).orElseThrow(BookClubNotFoundException::new);
 
         return ReadBookClubDetailResponse.from(bookClub);
+    }
+
+    private BookClubStatus getBookClubStatusOf(String statusName) {
+        if (statusName.equals(STATUS_ALL)) {
+            return null;
+        }
+        return BookClubStatus.of(statusName);
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/mapping/entity/BookClubMember.java
@@ -1,8 +1,5 @@
 package codesquad.bookkbookk.domain.mapping.entity;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -48,12 +45,6 @@ public class BookClubMember {
         if (bookClub != null) this.bookClubId = bookClub.getId();
         this.member = member;
         if (member != null) this.memberId = member.getId();
-    }
-
-    public static List<Member> toMembers(List<BookClubMember> bookClubMembers) {
-        return bookClubMembers.stream()
-                .map(BookClubMember::getMember)
-                .collect(Collectors.toUnmodifiableList());
     }
 
 }


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- 클래스의 상속으로 구현한 `ReadBookClubDetailResponse`를 추상 클래스로 변경합니다.
- `BookClub`에서 `List<Member>를 가져올 때 static method를 사용하지 않고 `BookClub`에서 변환하도록 변경했습니다.
- `BookClubStatus`에서 오버라이딩한 메서드가 구현체가 아니라 추상체를 반환하도록 변경했습니다.
  
### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 클래스의 상속으로 구현한 `ReadBookClubDetailResponse`를 추상 클래스로 변경합니다.
  - 공통 필드를 `ReadBookClubDetailResponse` 에 넣어놓고 상속 클래스들이 이를 사용하고 있는데, 공통 필드가 달라질 때마다 부모와 자식 클래스을 다 변경하는 이슈가 있습니다.
  - 추상 클래스로 변경하고 서비스 레이어에 있던 구현체 생성 책임을 추상 클래스에 두어 관심사를 분리합니다
- `BookClub`에서 `List<Member>를 가져올 때 static method를 사용하지 않고 `BookClub`에서 변환하도록 변경했습니다.
  - static method를 쓰는게 부자연스러웠습니다. 그동안 DTO를 만들기 위해서 static 메서드를 썼는데, 변환하는데 굳이 쓸 필요성을 못느꼈습니다.
-  `BookClubStatus`에서 오버라이딩한 메서드가 구현체가 아니라 추상체를 반환하도록 변경했습니다.
  - 다형성을 위해 구현체가 아닌 추상체를 반환하도록 시그니처를 변경했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
