### PR TITLE
[BE] `Chapter`, `Topic` Batch Insert 기능 구현

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/ChapterIdExistsException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/ChapterIdExistsException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ChapterIdExistsException extends ApiException{
+
+    public ChapterIdExistsException() {
+        super(HttpStatus.BAD_REQUEST, "Chapter Id가 존재합니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/LastInsertIdDoesNotExistException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/LastInsertIdDoesNotExistException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class LastInsertIdDoesNotExistException extends ApiException{
+
+    public LastInsertIdDoesNotExistException() {
+        super(HttpStatus.BAD_REQUEST, "마지막 insert 아이디가 존재하지 않습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/TopicIdExistsException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/TopicIdExistsException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class TopicIdExistsException extends ApiException{
+
+    public TopicIdExistsException() {
+        super(HttpStatus.BAD_REQUEST, "Topic Id가 존재합니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/data/entity/Chapter.java
@@ -16,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import codesquad.bookkbookk.common.error.exception.ChapterIdExistsException;
 import codesquad.bookkbookk.common.type.Status;
 import codesquad.bookkbookk.domain.book.data.entity.Book;
 import codesquad.bookkbookk.domain.chapter.data.dto.UpdateChapterRequest;
@@ -56,6 +57,11 @@ public class Chapter {
         if (book != null) this.bookId = book.getId();
         this.title = title;
         this.status = Status.BEFORE_READING;
+    }
+
+    public void setId(Long id) {
+        if (this.id != null) throw new ChapterIdExistsException();
+        this.id = id;
     }
 
     public boolean addTopic(Topic topic) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepository.java
@@ -8,5 +8,7 @@ import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 public interface ChapterCustomRepository {
 
     List<Chapter> findAllByBookIdAndStatus(Long bookId, Status status);
+    List<Chapter> saveAllInBatch(List<Chapter> chapters);
+
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
@@ -4,13 +4,18 @@ import static codesquad.bookkbookk.domain.bookmark.data.entity.QBookmark.*;
 import static codesquad.bookkbookk.domain.chapter.data.entity.QChapter.*;
 import static codesquad.bookkbookk.domain.topic.data.entity.QTopic.*;
 
+import java.sql.Types;
 import java.util.List;
 
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import codesquad.bookkbookk.common.error.exception.LastInsertIdDoesNotExistException;
 import codesquad.bookkbookk.common.type.Status;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 
@@ -20,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
 
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final JPAQueryFactory jpaQueryFactory;
 
     // TODO: 쿼리 성능 개선하기
@@ -36,11 +42,52 @@ public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
                 .fetch();
     }
 
+    @Override
+    public List<Chapter> saveAllInBulk(List<Chapter> chapters) {
+        String sql = "INSERT INTO chapter (book_id, status, title) VALUES (:book_id, :status, :title)";
+        SqlParameterSource[] batchParameters = createBatchParameters(chapters);
+
+        namedParameterJdbcTemplate.batchUpdate(sql, batchParameters);
+        setChapterIds(chapters);
+        return chapters;
+    }
+
     private BooleanExpression createChapterStatusCondition(Status status) {
         if (status == Status.ALL) {
             return null;
         }
         return chapter.status.eq(status);
+    }
+
+
+    private SqlParameterSource[] createBatchParameters(List<Chapter> chapters) {
+        SqlParameterSource[] batchParameters = new SqlParameterSource[chapters.size()];
+
+        for (int i = 0; i < chapters.size(); i++) {
+            Chapter chapter = chapters.get(i);
+            MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+            parameters.addValue("book_id", chapter.getBookId(), Types.BIGINT);
+            parameters.addValue("status", chapter.getStatus(), Types.VARCHAR);
+            parameters.addValue("title", chapter.getTitle(), Types.VARCHAR);
+            batchParameters[i] = parameters;
+        }
+        return batchParameters;
+    }
+
+    private void setChapterIds(List<Chapter> chapters) {
+        Long startId = namedParameterJdbcTemplate.getJdbcTemplate().queryForObject(
+                "SELECT LAST_INSERT_ID()", (rs, rowNum) -> rs.getLong("LAST_INSERT_ID()")
+        );
+
+        if (startId == null) {
+            throw new LastInsertIdDoesNotExistException();
+        }
+
+        for (int i = 0; i < chapters.size(); i++) {
+            chapters.get(i).setId(startId + i);
+        }
+
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/data/entity/Topic.java
@@ -14,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import codesquad.bookkbookk.common.error.exception.TopicIdExistsException;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 
@@ -47,6 +48,15 @@ public class Topic {
         this.chapter = chapter;
         if (chapter != null) this.chapterId = chapter.getId();
         this.title = title;
+    }
+
+    public void setId(Long id) {
+        if (this.id != null) throw new TopicIdExistsException();
+        this.id = id;
+    }
+
+    public void updateChapterId() {
+        if (chapter != null) chapterId = chapter.getId();
     }
 
     public boolean addBookmark(Bookmark bookmark) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepository.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.domain.topic.repository;
+
+import java.util.List;
+
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
+
+public interface TopicCustomRepository {
+
+    List<Topic> saveAllInBulk(List<Topic> topics);
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepositoryImpl.java
@@ -1,0 +1,61 @@
+package codesquad.bookkbookk.domain.topic.repository;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import codesquad.bookkbookk.common.error.exception.LastInsertIdDoesNotExistException;
+import codesquad.bookkbookk.domain.topic.data.entity.Topic;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TopicCustomRepositoryImpl implements TopicCustomRepository{
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public List<Topic> saveAllInBulk(List<Topic> topics) {
+        String sql = "INSERT INTO topic (chapter_id, title) VALUES (:chapter_id, :title)";
+        SqlParameterSource[] batchParameters = createBatchParameters(topics);
+
+        namedParameterJdbcTemplate.batchUpdate(sql, batchParameters);
+        setTopicIds(topics);
+        return topics;
+    }
+
+    private SqlParameterSource[] createBatchParameters(List<Topic> topics) {
+        SqlParameterSource[] batchParameters = new SqlParameterSource[topics.size()];
+
+        for (int i = 0; i < topics.size(); i++) {
+            Topic topic = topics.get(i);
+            MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+            parameters.addValue("chapter_id", topic.getChapterId(), Types.BIGINT);
+            parameters.addValue("title", topic.getTitle(), Types.VARCHAR);
+            batchParameters[i] = parameters;
+        }
+        return batchParameters;
+    }
+
+    private void setTopicIds(List<Topic> topics) {
+        Long startId = namedParameterJdbcTemplate.getJdbcTemplate().queryForObject(
+                "SELECT LAST_INSERT_ID()", (rs, rowNum) -> rs.getLong("LAST_INSERT_ID()")
+        );
+
+        if (startId == null) {
+            throw new LastInsertIdDoesNotExistException();
+        }
+
+        for (int i = 0; i < topics.size(); i++) {
+            topics.get(i).setId(startId + i);
+        }
+
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
-public interface TopicRepository extends JpaRepository<Topic, Long> {
+public interface TopicRepository extends JpaRepository<Topic, Long>, TopicCustomRepository {
 
     List<Topic> findByChapterId(Long chapterId);
 

--- a/be/src/test/java/codesquad/bookkbookk/unit/ChapterCustomRepositoryImplTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/ChapterCustomRepositoryImplTest.java
@@ -1,0 +1,68 @@
+package codesquad.bookkbookk.unit;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import codesquad.bookkbookk.common.config.QueryDslConfig;
+import codesquad.bookkbookk.domain.book.data.entity.Book;
+import codesquad.bookkbookk.domain.book.repository.BookRepository;
+import codesquad.bookkbookk.domain.bookclub.data.entity.BookClub;
+import codesquad.bookkbookk.domain.bookclub.repository.BookClubRepository;
+import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
+import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.util.TestDataFactory;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
+public class ChapterCustomRepositoryImplTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookClubRepository bookClubRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private ChapterRepository chapterRepository;
+
+    @Test
+    @DisplayName("Chapters를 Batch Insert한다.")
+    void saveChaptersInBatch() {
+        // given
+        Member member = TestDataFactory.createMember();
+        memberRepository.save(member);
+
+        BookClub bookClub = TestDataFactory.createBookClub(member);
+        bookClubRepository.save(bookClub);
+
+        Book book = TestDataFactory.createBook(bookClub);
+        bookRepository.save(book);
+
+        List<Chapter> chapters = TestDataFactory.createChapters(100, book);
+
+        // when
+        chapterRepository.saveAllInBatch(chapters);
+
+        // then
+        chapters.forEach(
+                chapter -> assertThat(chapter.getId()).isNotNull()
+        );
+    }
+
+}


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- `Chapter`와 `Topic`을 Batch Insert하고 아이디를 주입하는 기능을 만들었습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- Batch Insert 관련
  - 엔티티의 Id 생성 전략이 `Identity`로 DB에 책임이 있기에  JPA에서 제공해주는 Batch Insert는 사용할 수 없습니다.
  - 그렇다면 3가지 가능성이 있습니다.
    - `EntityManager. createNativeQuery()` 메서드를 활용
    - `JdbcTemplate.batchUpdate()` 메서드를 활용
    - `NamedParameterJdbcTemplate.batchUpdate()` 메서드를 활용
  - 이중에서 `NamedParameterJdbcTemplate`를 사용하여 파라미터가 매핑 될 때 순서가 아닌 변수명으로 관리하기 위함입니다.
- `LAST_INSERT_ID()`관련
  - Batch Insert를 할 때 아이디가 순차적으로 부여되는가
    - Mysql 공식문서에 따르면 이런 INSERT는 SImple Insert입니다. 그리고 Inno DB의 `AUTO_INCREMENT` 기본 락은 `interleaved lock mode`이고 Simple Insert에 대해서 순차적으로 아이디가 부여됨을 보장합니다.
  - `LAST_INSERT_ID()`가 영향을 받을 가능성은 없는가
    - `LAST_INSERT_ID()`는 db connection의 마지막 INSERT ID를 불러오고, 다른 connection의 영향을 받지 않습니다. 따라서 `LAST_INSET_ID()`는 Batch Insert 다음에 쓰인다면 다른 값이 들어갈 가능성이 없습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
