### PR TITLE
[BE] Batch Insert 기능이 DB에 의존적이지 않도록 리팩토링

### DIFF
--- a/be/src/main/java/codesquad/bookkbookk/common/error/exception/DatasourceNotConnectedException.java
+++ b/be/src/main/java/codesquad/bookkbookk/common/error/exception/DatasourceNotConnectedException.java
@@ -1,0 +1,11 @@
+package codesquad.bookkbookk.common.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DatasourceNotConnectedException extends ApiException{
+
+    public DatasourceNotConnectedException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "Datasource에 연결할 수 없습니다.");
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/repository/ChapterCustomRepositoryImpl.java
@@ -4,24 +4,17 @@ import static codesquad.bookkbookk.domain.bookmark.data.entity.QBookmark.*;
 import static codesquad.bookkbookk.domain.chapter.data.entity.QChapter.*;
 import static codesquad.bookkbookk.domain.topic.data.entity.QTopic.*;
 
+import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Types;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import javax.sql.DataSource;
-
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import codesquad.bookkbookk.common.error.exception.LastInsertIdDoesNotExistException;
+import codesquad.bookkbookk.common.error.exception.DatasourceNotConnectedException;
 import codesquad.bookkbookk.common.type.Status;
 import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 
@@ -31,7 +24,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
 
-    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private static final String CHAPTER_INSERT_PREFIX = "INSERT INTO chapter (book_id, status, title) VALUES ";
+
+    private final JdbcTemplate jdbcTemplate;
     private final JPAQueryFactory jpaQueryFactory;
 
     // TODO: 쿼리 성능 개선하기
@@ -50,10 +45,9 @@ public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
 
     @Override
     public List<Chapter> saveAllInBatch(List<Chapter> chapters) {
-        String sql = "INSERT INTO chapter (book_id, status, title) VALUES (:book_id, :status, :title)";
-        SqlParameterSource[] batchParameters = createBatchParameters(chapters);
+        String chaptersBatchInsertQuery = createChaptersBatchInsertQuery(chapters);
 
-        namedParameterJdbcTemplate.batchUpdate(sql, batchParameters);
+        jdbcTemplate.update(chaptersBatchInsertQuery);
         setChapterIds(chapters);
         return chapters;
     }
@@ -65,86 +59,68 @@ public class ChapterCustomRepositoryImpl implements ChapterCustomRepository {
         return chapter.status.eq(status);
     }
 
-
-    private SqlParameterSource[] createBatchParameters(List<Chapter> chapters) {
-        SqlParameterSource[] batchParameters = new SqlParameterSource[chapters.size()];
+    public String createChaptersBatchInsertQuery(List<Chapter> chapters) {
+        StringBuilder sb = new StringBuilder(CHAPTER_INSERT_PREFIX);
 
         for (int i = 0; i < chapters.size(); i++) {
-            Chapter chapter = chapters.get(i);
-            MapSqlParameterSource parameters = new MapSqlParameterSource();
+            appendChapterValue(chapters.get(i), sb);
 
-            parameters.addValue("book_id", chapter.getBookId(), Types.BIGINT);
-            parameters.addValue("status", chapter.getStatus(), Types.VARCHAR);
-            parameters.addValue("title", chapter.getTitle(), Types.VARCHAR);
-            batchParameters[i] = parameters;
+            if (i < chapters.size() - 1) {
+                sb.append(", ");
+            }
         }
-        return batchParameters;
+        return sb.toString();
+    }
+
+    private StringBuilder appendChapterValue(Chapter chapter, StringBuilder sb) {
+        return sb.append('(')
+                .append(chapter.getBookId()).append(", ")
+                .append('\'').append(chapter.getStatus().name()).append('\'').append(", ")
+                .append('\'').append(chapter.getTitle()).append('\'').append(')');
     }
 
     private void setChapterIds(List<Chapter> chapters) {
-        Long lastId = namedParameterJdbcTemplate.getJdbcTemplate().queryForObject(
-                "SELECT LAST_INSERT_ID()", (rs, rowNum) -> rs.getLong("LAST_INSERT_ID()")
-        );
+        String lastInsertIdQuery = "SELECT LAST_INSERT_ID()";
+        Long lastId = jdbcTemplate.queryForObject(lastInsertIdQuery, Long.class);
 
-        if (lastId == null) {
-            throw new LastInsertIdDoesNotExistException();
-        }
-
-        if (savedInBatch()) {
-            setIdsUsingFrontId(chapters, lastId);
-        }
-        else {
-            setIdsInUsingEndId(chapters, lastId);
+        if (isDatabaseH2()) {
+            setIdInDesc(chapters, lastId);
+        } else {
+            setIdInAsc(chapters, lastId);
         }
     }
 
-    private boolean savedInBatch() {
-        DataSource dataSource = namedParameterJdbcTemplate.getJdbcTemplate().getDataSource();
-        String datasourceUrl = null;
+    private boolean isDatabaseH2() {
+        String url;
+
         try {
-            datasourceUrl = dataSource.getConnection().getMetaData().getURL();
+            Connection connection = jdbcTemplate.getDataSource().getConnection();
+            url = connection.getMetaData().getURL();
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new DatasourceNotConnectedException();
         }
-        Map<String, String> properties = extractPropertiesFromDatasource(datasourceUrl);
 
-        return properties.getOrDefault("rewriteBatchedStatements", "").equals("true");
+        String databaseType = extractDatabaseType(url);
+        return databaseType.equals("h2");
     }
 
-    private Map<String, String> extractPropertiesFromDatasource(String datasourceUrl) {
-        Map<String, String> properties = new HashMap<>();
-
-        int paramsIndex = datasourceUrl.indexOf('?');
-        if (paramsIndex == -1) {
-            return Collections.emptyMap();
-        }
-
-        String paramsString = datasourceUrl.substring(paramsIndex + 1);
-        String[] params = paramsString.split("&");
-
-        for (String param : params) {
-            String[] keyValue = param.split("=", 2);
-            if (keyValue.length == 2) {
-                properties.put(keyValue[0], keyValue[1]);
-            } else {
-                properties.put(keyValue[0], "");
-            }
-        }
-
-        return properties;
+    private String extractDatabaseType(String url) {
+        String[] split = url.split(":");
+        return split[1];
     }
 
-    private void setIdsUsingFrontId(List<Chapter> chapters, Long lastId) {
-        for (int i = 0; i < chapters.size(); i++) {
-            chapters.get(i).setId(lastId + i);
+    private void setIdInAsc(List<Chapter> chapters, Long lastId) {
+        for (Chapter chapter : chapters) {
+            chapter.setId(lastId);
+            lastId++;
         }
     }
 
-    private void setIdsInUsingEndId(List<Chapter> chapters, Long lastId) {
-        for (int i = 0; i < chapters.size(); i++) {
-            chapters.get(i).setId(lastId - (chapters.size() - 1 - i));
+    private void setIdInDesc(List<Chapter> chapters, Long lastId) {
+        for (int i = chapters.size() - 1; i >= 0; i--) {
+            chapters.get(i).setId(lastId);
+            lastId--;
         }
     }
-
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/chapter/service/ChapterService.java
@@ -45,9 +45,9 @@ public class ChapterService {
 
         List<Topic> topics = chapters.stream()
                 .flatMap(chapter -> chapter.getTopics().stream())
-                .peek(Topic::updateChapterId)
                 .collect(Collectors.toUnmodifiableList());
-        topicRepository.saveAllInBulk(topics);
+        topics.forEach(Topic::updateChapterId);
+        topicRepository.saveAllInBatch(topics);
 
         return CreateChapterResponse.from(chapters);
     }

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/repository/TopicCustomRepository.java
@@ -6,6 +6,10 @@ import codesquad.bookkbookk.domain.topic.data.entity.Topic;
 
 public interface TopicCustomRepository {
 
-    List<Topic> saveAllInBulk(List<Topic> topics);
+    List<Topic> saveAllInBatch(List<Topic> topics);
 
 }
+
+
+
+


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- NamedParameterJdbcTemplate대신 JdbcTemplate를 사용하여 Batch Insert 기능을 구현했습니다.
- `NamedParameterJdbcTemplate.batchUpdate()`메서드 대신 Batch Insert 쿼리를 직접 작성하여 구현했습니다.
- 테스트 DB(H2), 와 운영DB(Mysql)을 구분하여서 Id를 주입하는 방법을 변경했습니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- NamedParameterJdbcTemplate대신 JdbcTemplate를 사용 & 쿼리를 직접 만듬
  - `JdbcTemplate.batchUpdate()`를 사용하여 Batch Insert하기 위해선 Mysql의 옵션이 필수적입니다. 이렇게 코드를 짜게 된다면 DB에 종속적이게 되어 DB를 변경할 때 힘들어집니다. 따라서 쿼리를 직접 작성하고 JdbcTemplate를 사용하여 쿼리를 실행합니다.
  - 쿼리를 실행시킬 떄 EntityManager과 JdbcTemplate 두 가지 방법이 있다고 생각하는데, `LAST_INSERT_ID()`가 DB의 종류에 따라 다르게 동작합니다. EntityManager에서는 DB의 종류를 알 수 없기에, JdbcTemplate를 사용했습니다.

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
