### PR TITLE
[BE] Bookmark, Comment, Reaction 한번에 가져오기 & Slice 적용하기

### DIFF
--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -76,7 +76,7 @@ operation::topic-documentation-test/update-topic[]
 operation::topic-documentation-test/delete-topic[]
 === 토픽의 북마크들 조회
 operation::topic-documentation-test/read-topic-bookmarks[]
-=== 토픽의 북마크들 슬라이스 해서 조회
+=== **토픽의 북마크들 슬라이스 해서 조회**
 operation::topic-documentation-test/read-topic-bookmark-slice[]
 
 == 북마크 API (/bookmarks)

--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -76,6 +76,8 @@ operation::topic-documentation-test/update-topic[]
 operation::topic-documentation-test/delete-topic[]
 === 토픽의 북마크들 조회
 operation::topic-documentation-test/read-topic-bookmarks[]
+=== 토픽의 북마크들 슬라이스 해서 조회
+operation::topic-documentation-test/read-topic-bookmark-slice[]
 
 == 북마크 API (/bookmarks)
 === 북마크 생성

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/dto/ReadBookmarkSliceResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/dto/ReadBookmarkSliceResponse.java
@@ -1,0 +1,91 @@
+package codesquad.bookkbookk.domain.bookmark.data.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Slice;
+
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
+import codesquad.bookkbookk.domain.comment.data.dto.ReadCommentSliceResponse;
+import codesquad.bookkbookk.domain.member.data.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadBookmarkSliceResponse {
+
+    private final List<ReadBookmarkSliceResponseBookmark> bookmarks;
+    private final boolean hasNext;
+
+    public static ReadBookmarkSliceResponse from(Slice<Bookmark> bookmarkSlice, Map<Long, ReadCommentSliceResponse> commentSliceMap) {
+        List<ReadBookmarkSliceResponseBookmark> bookmarks = bookmarkSlice.getContent().stream()
+                .map(bookmark -> ReadBookmarkSliceResponseBookmark.from(bookmark, commentSliceMap))
+                .collect(Collectors.toUnmodifiableList());
+
+        return new ReadBookmarkSliceResponse(bookmarks, bookmarkSlice.hasNext());
+    }
+
+    @Getter
+    private static class ReadBookmarkSliceResponseBookmark {
+
+        private final Long bookmarkId;
+        private final ReadBookmarkSliceResponseWriter author;
+        private final Integer page;
+        private final Instant createdTime;
+        private final Instant updatedTime;
+        private final String content;
+        private final ReadReactionsResponse reactions;
+        private final ReadCommentSliceResponse commentSlice;
+
+        @Builder
+        private ReadBookmarkSliceResponseBookmark(Long bookmarkId, ReadBookmarkSliceResponseWriter author, Integer page,
+                                                  Instant createdTime, Instant updatedTime, String content,
+                                                  ReadReactionsResponse reactions,
+                                                  ReadCommentSliceResponse commentSlice) {
+            this.bookmarkId = bookmarkId;
+            this.author = author;
+            this.page = page;
+            this.createdTime = createdTime;
+            this.updatedTime = updatedTime;
+            this.content = content;
+            this.reactions = reactions;
+            this.commentSlice = commentSlice;
+        }
+
+        private static ReadBookmarkSliceResponseBookmark from(Bookmark bookmark,
+                                                              Map<Long, ReadCommentSliceResponse> commentSliceMap) {
+            return ReadBookmarkSliceResponseBookmark.builder()
+                    .bookmarkId(bookmark.getId())
+                    .author(new ReadBookmarkSliceResponseWriter(bookmark.getWriter()))
+                    .page(bookmark.getPage())
+                    .createdTime(bookmark.getCreatedTime())
+                    .updatedTime(bookmark.getUpdatedTime())
+                    .content(bookmark.getContents())
+                    .reactions(ReadReactionsResponse.fromBookmarkReactions(bookmark.getBookmarkReactions()))
+                    .commentSlice(commentSliceMap.get(bookmark.getId()))
+                    .build();
+        }
+
+    }
+
+    @Getter
+    private static class ReadBookmarkSliceResponseWriter {
+
+        private final Long memberId;
+        private final String nickname;
+        private final String profileImageUrl;
+
+        private ReadBookmarkSliceResponseWriter(Member member) {
+            this.memberId = member.getId();
+            this.nickname = member.getNickname();
+            this.profileImageUrl = member.getProfileImageUrl();
+        }
+
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/dto/ReadReactionsResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/data/dto/ReadReactionsResponse.java
@@ -18,15 +18,19 @@ public class ReadReactionsResponse {
     @JsonProperty(value = "like")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final List<String> likeReactorNames = new ArrayList<>();
+
     @JsonProperty(value = "love")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final List<String> loveReactorNames = new ArrayList<>();
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(value = "clap")
     private final List<String> clapReactorNames= new ArrayList<>();
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(value = "congratulation")
     private final List<String> congratulationReactorNames= new ArrayList<>();
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(value = "rocket")
     private final List<String> rocketReactorNames= new ArrayList<>();
@@ -43,6 +47,30 @@ public class ReadReactionsResponse {
 
         commentReactions.forEach(response::addName);
         return response;
+    }
+
+    public void addName(String nickname, String reactionName) {
+        Reaction reaction = Reaction.of(reactionName);
+
+        if (reaction.equals(Reaction.LIKE)) {
+            likeReactorNames.add(nickname);
+            return;
+        }
+        if (reaction.equals(Reaction.LOVE)) {
+            loveReactorNames.add(nickname);
+            return;
+        }
+        if (reaction.equals(Reaction.CLAP)) {
+            clapReactorNames.add(nickname);
+            return;
+        }
+        if (reaction.equals(Reaction.CONGRATULATION)) {
+            congratulationReactorNames.add(nickname);
+            return;
+        }
+        if (reaction.equals(Reaction.ROCKET)) {
+            rocketReactorNames.add(nickname);
+        }
     }
 
     private void addName(BookmarkReaction bookmarkReaction) {

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepository.java
@@ -2,6 +2,9 @@ package codesquad.bookkbookk.domain.bookmark.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import codesquad.bookkbookk.domain.bookmark.data.dto.BookmarkFilter;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 
@@ -10,5 +13,7 @@ public interface BookmarkCustomRepository {
     List<Bookmark> findAllByFilter(Long bookId, BookmarkFilter bookmarkFilter);
 
     List<Bookmark> findAllByTopicId(Long topicId);
+
+    Slice<Bookmark> findSliceByTopicId(Long topicId, Pageable pageable);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/bookmark/repository/BookmarkCustomRepositoryImpl.java
@@ -57,6 +57,7 @@ public class BookmarkCustomRepositoryImpl implements BookmarkCustomRepository {
     public Slice<Bookmark> findSliceByTopicId(Long topicId, Pageable pageable) {
         List<Bookmark> bookmarks = jpaQueryFactory
                 .selectFrom(bookmark)
+                .innerJoin(bookmark.writer, member).fetchJoin()
                 .innerJoin(bookmark.bookmarkReactions, bookmarkReaction).fetchJoin()
                 .innerJoin(bookmarkReaction.reactor, member).fetchJoin()
                 .where(bookmark.topicId.eq(topicId))

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/dto/ReadCommentSliceResponse.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/dto/ReadCommentSliceResponse.java
@@ -1,0 +1,93 @@
+package codesquad.bookkbookk.domain.comment.data.dto;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import codesquad.bookkbookk.domain.bookmark.data.dto.ReadReactionsResponse;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadCommentSliceResponse {
+
+    @JsonIgnore
+    private final Map<Long, ReadCommentSliceResponseComment> commentMap;
+    private final List<ReadCommentSliceResponseComment> comments;
+    private boolean hasNext;
+
+    public ReadCommentSliceResponse() {
+        this.comments = new ArrayList<>();
+        this.commentMap = new HashMap<>();
+    }
+
+    public void addComment(Long commentId, Long writerId, String writerNickname, String writerProfileImageUrl,
+                           Instant createdTime, String content) {
+        if (this.commentMap.containsKey(commentId)) return;
+
+        ReadCommentSliceResponseComment comment = ReadCommentSliceResponseComment.builder()
+                .commentId(commentId)
+                .author(new ReadCommentSliceResponseWriter(writerId, writerNickname, writerProfileImageUrl))
+                .createdTime(createdTime)
+                .content(content)
+                .build();
+
+        this.comments.add(comment);
+        this.commentMap.put(commentId, comment);
+    }
+
+    public void addCommentReaction(Long commentId, String reactorNickname, String reactionName) {
+        if (reactorNickname == null || reactionName == null) return;
+        ReadCommentSliceResponseComment comment = commentMap.get(commentId);
+
+        comment.reactions.addName(reactorNickname, reactionName);
+    }
+
+    public void markAsHasNext() {
+        this.hasNext = true;
+    }
+
+    @Getter
+    private static class ReadCommentSliceResponseComment {
+
+        private final Long commentId;
+        private final ReadCommentSliceResponseWriter author;
+        private final Instant createdTime;
+        private final String content;
+        private final ReadReactionsResponse reactions;
+
+        @Builder
+        private ReadCommentSliceResponseComment(Long commentId, ReadCommentSliceResponseWriter author,
+                                                Instant createdTime, String content) {
+            this.commentId = commentId;
+            this.author = author;
+            this.createdTime = createdTime;
+            this.content = content;
+            this.reactions = new ReadReactionsResponse();
+        }
+
+    }
+
+    @Getter
+    private static class ReadCommentSliceResponseWriter {
+
+        private final Long memberId;
+        private final String nickname;
+        private final String profileImageUrl;
+
+        private ReadCommentSliceResponseWriter(Long memberId, String nickname, String profileImageUrl) {
+            this.memberId = memberId;
+            this.nickname = nickname;
+            this.profileImageUrl = profileImageUrl;
+        }
+
+    }
+
+}

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/data/entity/Comment.java
@@ -11,9 +11,11 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -28,6 +30,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_comment_created_time", columnList = "createdTime")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Comment {

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepository.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepository.java
@@ -1,11 +1,15 @@
 package codesquad.bookkbookk.domain.comment.repository;
 
 import java.util.List;
+import java.util.Map;
 
+import codesquad.bookkbookk.domain.comment.data.dto.ReadCommentSliceResponse;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 
 public interface CommentCustomRepository {
 
     List<Comment> findAllByBookmarkId(Long bookmarkId);
+
+    Map<Long, ReadCommentSliceResponse> findSlicesByBookmarkIds(List<Long> bookmarkIds, Integer size);
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -2,21 +2,33 @@ package codesquad.bookkbookk.domain.comment.repository;
 
 import static codesquad.bookkbookk.domain.comment.data.entity.QComment.*;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import codesquad.bookkbookk.domain.comment.data.dto.ReadCommentSliceResponse;
 import codesquad.bookkbookk.domain.comment.data.entity.Comment;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentCustomRepositoryImpl implements CommentCustomRepository{
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
 
     @Override
     public List<Comment> findAllByBookmarkId(Long bookmarkId) {
@@ -25,6 +37,111 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
                 .innerJoin(comment.writer).fetchJoin()
                 .where(comment.bookmark.id.eq(bookmarkId))
                 .fetch();
+    }
+
+    @Override
+    public Map<Long, ReadCommentSliceResponse> findSlicesByBookmarkIds(List<Long> bookmarkIds, Integer size) {
+        List<Long> commentIds = new ArrayList<>();
+        Map<Long, ReadCommentSliceResponse> commentSliceMap = findCommentSliceMap(bookmarkIds, size, commentIds);
+
+        addCommentReactionToCommentSlices(commentSliceMap, commentIds);
+
+        return commentSliceMap;
+    }
+
+    private Map<Long, ReadCommentSliceResponse> findCommentSliceMap(List<Long> bookmarkIds, Integer size,
+                                                                    List<Long> commentIds) {
+        String bookmarkIdsStr = IntStream.range(1, bookmarkIds.size() + 1)
+                .mapToObj(i -> ":bookmarkId" + i)
+                .collect(Collectors.joining(", "));
+        String commentSliceQuery =  "WITH numbered_comment AS " +
+                "(SELECT c.comment_id, c.bookmark_id, c.writer_id, c.contents, c.created_time, " +
+                "w.nickname AS writer_nickname, w.profile_image_url AS writer_profile_image_url, " +
+                "ROW_NUMBER() OVER (PARTITION BY c.bookmark_id ORDER BY c.created_time DESC, c.comment_id DESC) AS row_num " +
+                "FROM comment c " +
+                "INNER JOIN member w ON c.writer_id = w.member_id " +
+                "WHERE c.bookmark_id IN (" + bookmarkIdsStr + ")) " +
+                "SELECT * " +
+                "FROM numbered_comment nc " +
+                "WHERE nc.row_num <= :size " +
+                "ORDER BY nc.created_time DESC, nc.comment_id DESC ";
+
+        MapSqlParameterSource commentSliceParameters = createCommentSliceParameters(bookmarkIds, size);
+
+        Map<Long, ReadCommentSliceResponse> commentSliceMap = new HashMap<>();
+
+        jdbcTemplate.query(commentSliceQuery, commentSliceParameters, rs -> {
+            Long bookmarkId = rs.getLong("bookmark_id");
+            ReadCommentSliceResponse commentSlice = commentSliceMap.computeIfAbsent(bookmarkId, id -> new ReadCommentSliceResponse());
+
+            if (isLastComment(rs, size, commentSlice)) {
+                return;
+            }
+            addCommentToCommentSlice(rs, commentSlice, commentIds);
+        });
+        return commentSliceMap;
+    }
+
+    private  void addCommentReactionToCommentSlices(Map<Long, ReadCommentSliceResponse> commentSliceMap, List<Long> commentIds) {
+        String commentIdsStr = IntStream.range(1, commentIds.size() + 1)
+                .mapToObj(i -> ":commentId" + i)
+                .collect(Collectors.joining(", "));
+        String findCommentReactionsNativeQuery = "SELECT cr.reaction, cr.comment_id, r.nickname, c.bookmark_id " +
+                "FROM comment_reaction cr " +
+                "INNER JOIN comment c ON cr.comment_id = c.comment_id " +
+                "INNER JOIN member r ON cr.reactor_id = r.member_id " +
+                "WHERE cr.comment_id IN (" + commentIdsStr + ")";
+
+        MapSqlParameterSource commentReactionParameters = createCommentReactionParameters(commentIds);
+
+        jdbcTemplate.query(findCommentReactionsNativeQuery, commentReactionParameters, rs -> {
+            Long bookmarkId = rs.getLong("bookmark_id");
+            ReadCommentSliceResponse commentSlice = commentSliceMap.get(bookmarkId);
+
+            Long commentId = rs.getLong("comment_id");
+            String reactorNickname = rs.getString("nickname");
+            String reactionName = rs.getString("reaction");
+            commentSlice.addCommentReaction(commentId, reactorNickname, reactionName);
+        });
+    }
+
+    private MapSqlParameterSource createCommentSliceParameters(List<Long> bookmarkIds, Integer size) {
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+        parameters.addValue("size", size + 1);
+        for (int i = 1; i <= bookmarkIds.size(); i++) {
+            parameters.addValue("bookmarkId" + i, bookmarkIds.get(i - 1));
+        }
+        return parameters;
+    }
+
+    private boolean isLastComment(ResultSet rs, Integer size, ReadCommentSliceResponse commentSlice) throws SQLException {
+        int rowNum = rs.getInt("row_num");
+        if (rowNum > size) {
+            commentSlice.markAsHasNext();
+            return true;
+        }
+        return false;
+    }
+
+    private void addCommentToCommentSlice(ResultSet rs, ReadCommentSliceResponse commentSlice, List<Long> commentIds) throws SQLException {
+        Long commentId = rs.getLong("comment_id");
+        Long writerId = rs.getLong("writer_id");
+        String writerNickname = rs.getString("writer_nickname");
+        String writerProfileImageUrl = rs.getString("writer_profile_image_url");
+        String contents = rs.getString("contents");
+        Instant createdTime = rs.getTimestamp("created_time").toInstant();
+
+        commentSlice.addComment(commentId, writerId, writerNickname, writerProfileImageUrl, createdTime, contents);
+        commentIds.add(commentId);
+    }
+
+    private MapSqlParameterSource createCommentReactionParameters(List<Long> commentIds) {
+        MapSqlParameterSource commentReactionParameters = new MapSqlParameterSource();
+        for (int i = 1; i <= commentIds.size(); i++) {
+            commentReactionParameters.addValue("commentId" + i, commentIds.get(i - 1));
+        }
+        return commentReactionParameters;
     }
 
 }

--- a/be/src/main/java/codesquad/bookkbookk/domain/topic/controller/TopicController.java
+++ b/be/src/main/java/codesquad/bookkbookk/domain/topic/controller/TopicController.java
@@ -2,6 +2,8 @@ package codesquad.bookkbookk.domain.topic.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +12,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.bookkbookk.common.resolver.MemberId;
 import codesquad.bookkbookk.domain.bookmark.data.dto.ReadBookmarkResponse;
+import codesquad.bookkbookk.domain.bookmark.data.dto.ReadBookmarkSliceResponse;
 import codesquad.bookkbookk.domain.bookmark.service.BookmarkService;
 import codesquad.bookkbookk.domain.topic.data.dto.CreateTopicRequest;
 import codesquad.bookkbookk.domain.topic.data.dto.CreateTopicResponse;
@@ -46,6 +50,17 @@ public class TopicController {
 
         return ResponseEntity.ok()
                 .body(responses);
+    }
+
+    @GetMapping("/{topicId}/bookmarks/slice")
+    public ResponseEntity<ReadBookmarkSliceResponse> readBookmarks(@MemberId Long memberId, @PathVariable Long topicId,
+                                                                   @RequestParam Integer cursor,
+                                                                   @RequestParam Integer size) {
+        Pageable pageable = PageRequest.of(cursor, size);
+        ReadBookmarkSliceResponse response = bookmarkService.readBookmarkSlices(memberId, topicId, pageable);
+
+        return ResponseEntity.ok()
+                .body(response);
     }
 
     @PatchMapping("/{topicId}")

--- a/be/src/main/resources/insertBookmarks.sql
+++ b/be/src/main/resources/insertBookmarks.sql
@@ -1,0 +1,23 @@
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE bookmark;
+DROP PROCEDURE IF EXISTS InsertBookmarks;
+
+DELIMITER //
+
+CREATE PROCEDURE InsertBookmarks()
+BEGIN
+    DECLARE counter INT DEFAULT 1;
+    DECLARE base_date DATETIME DEFAULT '2000-01-01 00:00:00';
+
+    WHILE counter <= 1000 DO
+            INSERT INTO bookmark (topic_id, writer_id, page, contents, created_time)
+            VALUES (1, 1, counter, 'content', DATE_ADD(base_date, INTERVAL counter DAY));
+            SET counter = counter + 1;
+        END WHILE;
+END //
+
+DELIMITER ;
+
+CALL InsertBookmarks();
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/be/src/main/resources/insertComments.sql
+++ b/be/src/main/resources/insertComments.sql
@@ -1,0 +1,25 @@
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE comment;
+DROP PROCEDURE IF EXISTS InsertComments;
+
+DELIMITER //
+
+CREATE PROCEDURE InsertComments()
+BEGIN
+    DECLARE counter INT DEFAULT 1;
+    DECLARE bookmark_id INT DEFAULT 1;
+    DECLARE base_date DATETIME DEFAULT '2000-01-01 00:00:00';
+
+    WHILE counter <= 20000 DO
+            INSERT INTO comment (bookmark_id, writer_id, contents, created_time)
+            VALUES (bookmark_id, 1, 'content', DATE_ADD(base_date, INTERVAL counter SECOND));
+            SET bookmark_id = (bookmark_id % 100) + 1;
+            SET counter = counter + 1;
+        END WHILE;
+END //
+
+DELIMITER ;
+
+CALL InsertComments();
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/be/src/main/resources/schema.sql
+++ b/be/src/main/resources/schema.sql
@@ -145,6 +145,7 @@ CREATE TABLE comment
     CONSTRAINT fk_comment_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (bookmark_id),
     CONSTRAINT fk_comment_member FOREIGN KEY (writer_id) REFERENCES member (member_id)
 );
+CREATE INDEX idx_comment_created_time ON comment (created_time);
 
 CREATE TABLE comment_reaction
 (

--- a/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
@@ -52,6 +52,8 @@ public class BookmarkRepositoryTest {
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(bookmarkSlice.hasNext()).isTrue();
+            softAssertions.assertThat(bookmarkSlice.getContent().size()).isEqualTo(5);
+            softAssertions.assertThat(bookmarkSlice.getContent().get(3).getBookmarkReactions().size()).isEqualTo(4);
             softAssertions.assertThat(bookmarkSlice.getContent().get(0).getCreatedTime())
                     .isEqualTo(Instant.parse("2000-01-07T00:00:00Z"));
         });

--- a/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
@@ -1,0 +1,68 @@
+package codesquad.bookkbookk.unit;
+
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import codesquad.bookkbookk.common.config.QueryDslConfig;
+import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
+import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
+public class BookmarkRepositoryTest {
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    @Test
+    @DisplayName("Bookmark의 Slice를 가져온다.")
+    @Sql("classpath:sql/readBookmarkSlice.sql")
+    void readBookmarkSlice() {
+        // given
+        Pageable pageable = PageRequest.of(0, 5);
+
+        // when
+        Slice<Bookmark> bookmarkSlice = bookmarkRepository.findSliceByTopicId(1L, pageable);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(bookmarkSlice.hasNext()).isTrue();
+            softAssertions.assertThat(bookmarkSlice.getContent().get(0).getCreatedTime())
+                    .isEqualTo(Instant.parse("2000-01-07T00:00:00Z"));
+        });
+    }
+
+    @Test
+    @DisplayName("Bookmark의 마지막 Slice를 가져온다.")
+    @Sql("classpath:sql/readBookmarkSlice.sql")
+    void readBookmarkLastSlice() {
+        // given
+        Pageable pageable = PageRequest.of(1, 5);
+
+        // when
+        Slice<Bookmark> bookmarkSlice = bookmarkRepository.findSliceByTopicId(1L, pageable);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(bookmarkSlice.hasNext()).isFalse();
+            softAssertions.assertThat(bookmarkSlice.getContent().get(0).getCreatedTime())
+                    .isEqualTo(Instant.parse("2000-01-02T00:00:00Z"));
+        });
+    }
+
+}

--- a/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/BookmarkRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.SoftAssertions.*;
 
 import java.time.Instant;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,15 +20,24 @@ import org.springframework.test.context.jdbc.Sql;
 import codesquad.bookkbookk.common.config.QueryDslConfig;
 import codesquad.bookkbookk.domain.bookmark.data.entity.Bookmark;
 import codesquad.bookkbookk.domain.bookmark.repository.BookmarkRepository;
+import codesquad.bookkbookk.util.DatabaseCleaner;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(QueryDslConfig.class)
+@Import({QueryDslConfig.class, DatabaseCleaner.class})
 public class BookmarkRepositoryTest {
 
     @Autowired
     private BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleaner.execute();
+    }
 
     @Test
     @DisplayName("Bookmark의 Slice를 가져온다.")

--- a/be/src/test/java/codesquad/bookkbookk/unit/ChapterCustomRepositoryImplTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/ChapterCustomRepositoryImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,12 +22,13 @@ import codesquad.bookkbookk.domain.chapter.data.entity.Chapter;
 import codesquad.bookkbookk.domain.chapter.repository.ChapterRepository;
 import codesquad.bookkbookk.domain.member.data.entity.Member;
 import codesquad.bookkbookk.domain.member.repository.MemberRepository;
+import codesquad.bookkbookk.util.DatabaseCleaner;
 import codesquad.bookkbookk.util.TestDataFactory;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(QueryDslConfig.class)
+@Import({QueryDslConfig.class, DatabaseCleaner.class})
 public class ChapterCustomRepositoryImplTest {
 
     @Autowired
@@ -40,6 +42,14 @@ public class ChapterCustomRepositoryImplTest {
 
     @Autowired
     private ChapterRepository chapterRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleaner.execute();
+    }
 
     @Test
     @DisplayName("Chapters를 Batch Insert한다.")

--- a/be/src/test/java/codesquad/bookkbookk/unit/CommentRepositoryTest.java
+++ b/be/src/test/java/codesquad/bookkbookk/unit/CommentRepositoryTest.java
@@ -1,0 +1,60 @@
+package codesquad.bookkbookk.unit;
+
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import codesquad.bookkbookk.common.config.QueryDslConfig;
+import codesquad.bookkbookk.domain.comment.data.dto.ReadCommentSliceResponse;
+import codesquad.bookkbookk.domain.comment.repository.CommentRepository;
+import codesquad.bookkbookk.util.DatabaseCleaner;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class, DatabaseCleaner.class})
+public class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleaner.execute();
+    }
+
+    @Test
+    @DisplayName("Comment의 Slice를 가져온다.")
+    @Sql("classpath:sql/readCommentSlice.sql")
+    void readBookmarkSlice() {
+        // given
+        List<Long> bookmarkIds = List.of(1L, 2L, 3L, 4L, 5L);
+        int size = 5;
+
+        // when
+        Map<Long, ReadCommentSliceResponse> commentSlicesMap = commentRepository.findSlicesByBookmarkIds(bookmarkIds, size);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(commentSlicesMap.get(1L).isHasNext()).isTrue();
+            softAssertions.assertThat(commentSlicesMap.get(2L).isHasNext()).isFalse();
+            softAssertions.assertThat(commentSlicesMap.get(5L).isHasNext()).isFalse();
+            softAssertions.assertThat(commentSlicesMap.get(5L).getComments().size()).isEqualTo(3);
+        });
+    }
+
+}

--- a/be/src/test/resources/sql/readBookmarkSlice.sql
+++ b/be/src/test/resources/sql/readBookmarkSlice.sql
@@ -1,0 +1,53 @@
+INSERT INTO member (login_type, email, nickname, profile_image_url)
+VALUES ('GOOGLE', 'nag@gmail.com', '나그', 'profile'),
+       ('GOOGLE', 'zoey@naver.com', '조이', 'profile'),
+       ('GOOGLE', 'asdf@naver.com', '익명', 'profile'),
+       ('GOOGLE', 'gamgyul@naver.com', '감귤', 'profile');
+
+INSERT INTO book_club (created_time, creator_id, name, profile_image_url, status)
+VALUES ('2023-12-31 00:00:00', 1, '테스트', 'https://lh3.googleusercontent.com/a/ACg8ocI4UdR_y6c32pL94MdKHJwDGcGh2jU8a6eB-A6gQtSi0mRarzaG=s96-c', 'OPEN');
+
+INSERT INTO book_club_member (book_club_id, member_id)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 4);
+
+INSERT INTO book (book_club_id, author, category, cover, isbn, status, title)
+VALUES (1, '신용권 (지은이)', '국내도서>컴퓨터/모바일>프로그래밍 언어>자바', 'https://image.aladin.co.kr/product/33323/64/coversum/k502938683_1.jpg', '9791169211901', 'BEFORE_READING', '혼자 공부하는 자바 - 1:1 과외하듯 배우는 프로그래밍 자습서, 개정판');
+
+INSERT INTO member_book (book_id, member_id)
+VALUES (1, 1);
+
+INSERT INTO chapter (book_id, status, title)
+VALUES (1, 'BEFORE_READING', '챕터 1');
+
+INSERT INTO topic (chapter_id, title)
+VALUES (1, '토픽 1');
+
+INSERT INTO bookmark (topic_id, writer_id, page, contents, created_time, updated_time)
+VALUES (1, 1, 123, 'content', '2000-01-01 00:00:00', '2000-01-01 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-02 00:00:00', '2000-01-02 00:00:00'),
+       (1, 3, 123, 'content', '2000-01-03 00:00:00', '2000-01-03 00:00:00'),
+       (1, 1, 123, 'content', '2000-01-04 00:00:00', '2000-01-04 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-05 00:00:00', '2000-01-05 00:00:00'),
+       (1, 3, 123, 'content', '2000-01-06 00:00:00', '2000-01-06 00:00:00'),
+       (1, 1, 123, 'content', '2000-01-07 00:00:00', '2000-01-07 00:00:00');
+
+INSERT INTO bookmark_reaction (bookmark_id, reactor_id, reaction)
+VALUES (1, 1, 'CLAP'),
+       (1, 2, 'CONGRATULATION'),
+       (2, 1, 'LOVE'),
+       (2, 2, 'ROCKET'),
+       (2, 3, 'LIKE'),
+       (2, 3, 'CONGRATULATION'),
+       (2, 1, 'CONGRATULATION'),
+       (4, 2, 'LIKE'),
+       (4, 2, 'LOVE'),
+       (4, 2, 'CLAP'),
+       (4, 1, 'CLAP'),
+       (5, 1, 'ROCKET'),
+       (5, 2, 'ROCKET'),
+       (5, 4, 'ROCKET'),
+       (5, 3, 'ROCKET'),
+       (5, 1, 'LIKE');

--- a/be/src/test/resources/sql/readCommentSlice.sql
+++ b/be/src/test/resources/sql/readCommentSlice.sql
@@ -1,0 +1,85 @@
+INSERT INTO member (login_type, email, nickname, profile_image_url)
+VALUES ('GOOGLE', 'nag@gmail.com', '나그', 'profile'),
+       ('GOOGLE', 'zoey@naver.com', '조이', 'profile'),
+       ('GOOGLE', 'asdf@naver.com', '익명', 'profile'),
+       ('GOOGLE', 'gamgyul@naver.com', '감귤', 'profile');
+
+INSERT INTO book_club (created_time, creator_id, name, profile_image_url, status)
+VALUES ('2023-12-31 00:00:00', 1, '테스트', 'https://lh3.googleusercontent.com/a/ACg8ocI4UdR_y6c32pL94MdKHJwDGcGh2jU8a6eB-A6gQtSi0mRarzaG=s96-c', 'OPEN');
+
+INSERT INTO book_club_member (book_club_id, member_id)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 4);
+
+INSERT INTO book (book_club_id, author, category, cover, isbn, status, title)
+VALUES (1, '신용권 (지은이)', '국내도서>컴퓨터/모바일>프로그래밍 언어>자바', 'https://image.aladin.co.kr/product/33323/64/coversum/k502938683_1.jpg', '9791169211901', 'BEFORE_READING', '혼자 공부하는 자바 - 1:1 과외하듯 배우는 프로그래밍 자습서, 개정판');
+
+INSERT INTO member_book (book_id, member_id)
+VALUES (1, 1);
+
+INSERT INTO chapter (book_id, status, title)
+VALUES (1, 'BEFORE_READING', '챕터 1');
+
+INSERT INTO topic (chapter_id, title)
+VALUES (1, '토픽 1');
+
+INSERT INTO bookmark (topic_id, writer_id, page, contents, created_time, updated_time)
+VALUES (1, 1, 123, 'content', '2000-01-01 00:00:00', '2000-01-01 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-02 00:00:00', '2000-01-02 00:00:00'),
+       (1, 3, 123, 'content', '2000-01-03 00:00:00', '2000-01-03 00:00:00'),
+       (1, 1, 123, 'content', '2000-01-04 00:00:00', '2000-01-04 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-05 00:00:00', '2000-01-05 00:00:00'),
+       (1, 3, 123, 'content', '2000-01-06 00:00:00', '2000-01-06 00:00:00'),
+       (1, 1, 123, 'content', '2000-01-07 00:00:00', '2000-01-07 00:00:00');
+
+INSERT INTO comment (bookmark_id, writer_id, contents, created_time, updated_time)
+VALUES (1, 1, 'content', '2000-01-01 00:00:00', '2000-01-01 00:00:00'),
+       (1, 2, 'content', '2000-01-02 00:00:00', '2000-01-02 00:00:00'),
+       (1, 3, 'content', '2000-01-03 00:00:00', '2000-01-03 00:00:00'),
+       (1, 1, 'content', '2000-01-04 00:00:00', '2000-01-04 00:00:00'),
+       (1, 2, 'content', '2000-01-05 00:00:00', '2000-01-05 00:00:00'),
+       (1, 3, 'content', '2000-01-06 00:00:00', '2000-01-06 00:00:00'),
+       (2, 3, 'content', '2000-01-07 00:00:00', '2000-01-07 00:00:00'),
+       (2, 2, 'content', '2000-01-08 00:00:00', '2000-01-08 00:00:00'),
+       (2, 3, 'content', '2000-01-09 00:00:00', '2000-01-09 00:00:00'),
+       (2, 1, 'content', '2000-01-10 00:00:00', '2000-01-10 00:00:00'),
+       (2, 1, 'content', '2000-01-11 00:00:00', '2000-01-11 00:00:00'),
+       (3, 2, 'content', '2000-01-12 00:00:00', '2000-01-12 00:00:00'),
+       (3, 3, 'content', '2000-01-13 00:00:00', '2000-01-13 00:00:00'),
+       (3, 2, 'content', '2000-01-14 00:00:00', '2000-01-14 00:00:00'),
+       (3, 2, 'content', '2000-01-15 00:00:00', '2000-01-15 00:00:00'),
+       (3, 1, 'content', '2000-01-16 00:00:00', '2000-01-16 00:00:00'),
+       (3, 1, 'content', '2000-01-17 00:00:00', '2000-01-17 00:00:00'),
+       (4, 1, 'content', '2000-01-18 00:00:00', '2000-01-18 00:00:00'),
+       (4, 3, 'content', '2000-01-19 00:00:00', '2000-01-19 00:00:00'),
+       (4, 2, 'content', '2000-01-20 00:00:00', '2000-01-20 00:00:00'),
+       (4, 1, 'content', '2000-01-21 00:00:00', '2000-01-21 00:00:00'),
+       (4, 1, 'content', '2000-01-22 00:00:00', '2000-01-22 00:00:00'),
+       (5, 3, 'content', '2000-01-23 00:00:00', '2000-01-23 00:00:00'),
+       (5, 2, 'content', '2000-01-24 00:00:00', '2000-01-24 00:00:00'),
+       (5, 1, 'content', '2000-01-25 00:00:00', '2000-01-25 00:00:00');
+
+INSERT INTO comment_reaction (comment_id, reactor_id, reaction)
+VALUES (1, 1, 'CLAP'),
+       (1, 2, 'CONGRATULATION'),
+       (2, 1, 'LOVE'),
+       (2, 2, 'ROCKET'),
+       (2, 3, 'LIKE'),
+       (2, 3, 'CONGRATULATION'),
+       (2, 1, 'CONGRATULATION'),
+       (4, 2, 'LIKE'),
+       (4, 2, 'LOVE'),
+       (4, 2, 'CLAP'),
+       (4, 1, 'CLAP'),
+       (5, 1, 'ROCKET'),
+       (5, 2, 'ROCKET'),
+       (5, 4, 'ROCKET'),
+       (5, 3, 'ROCKET'),
+       (5, 1, 'LIKE'),
+       (20, 1, 'ROCKET'),
+       (19, 2, 'ROCKET'),
+       (10, 3, 'ROCKET'),
+       (15, 4, 'ROCKET'),
+       (20, 3, 'ROCKET');

--- a/be/src/test/resources/sql/readTopicBookmarkSlice.sql
+++ b/be/src/test/resources/sql/readTopicBookmarkSlice.sql
@@ -1,0 +1,84 @@
+INSERT INTO member (login_type, email, nickname, profile_image_url)
+VALUES ('GOOGLE', 'nag@gmail.com', '나그', 'profile'),
+       ('GOOGLE', 'zoey@naver.com', '조이', 'profile'),
+       ('GOOGLE', 'asdf@naver.com', '익명', 'profile'),
+       ('GOOGLE', 'gamgyul@naver.com', '감귤', 'profile');
+
+INSERT INTO book_club (created_time, creator_id, name, profile_image_url, status)
+VALUES ('2023-12-31 00:00:00', 1, '테스트', 'https://lh3.googleusercontent.com/a/ACg8ocI4UdR_y6c32pL94MdKHJwDGcGh2jU8a6eB-A6gQtSi0mRarzaG=s96-c', 'OPEN');
+
+INSERT INTO book_club_member (book_club_id, member_id)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 4);
+
+INSERT INTO book (book_club_id, author, category, cover, isbn, status, title)
+VALUES (1, '신용권 (지은이)', '국내도서>컴퓨터/모바일>프로그래밍 언어>자바', 'https://image.aladin.co.kr/product/33323/64/coversum/k502938683_1.jpg', '9791169211901', 'BEFORE_READING', '혼자 공부하는 자바 - 1:1 과외하듯 배우는 프로그래밍 자습서, 개정판');
+
+INSERT INTO member_book (book_id, member_id)
+VALUES (1, 1);
+
+INSERT INTO chapter (book_id, status, title)
+VALUES (1, 'BEFORE_READING', '챕터 1');
+
+INSERT INTO topic (chapter_id, title)
+VALUES (1, '토픽 1');
+
+INSERT INTO bookmark (topic_id, writer_id, page, contents, created_time, updated_time)
+VALUES (1, 1, 123, 'content', '2000-01-01 00:00:00', '2000-01-01 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-02 00:00:00', '2000-01-02 00:00:00'),
+       (1, 3, 123, 'content', '2000-01-03 00:00:00', '2000-01-03 00:00:00'),
+       (1, 1, 123, 'content', '2000-01-04 00:00:00', '2000-01-04 00:00:00'),
+       (1, 2, 123, 'content', '2000-01-05 00:00:00', '2000-01-05 00:00:00');
+
+       INSERT INTO bookmark_reaction (bookmark_id, reactor_id, reaction)
+VALUES (1, 1, 'CLAP'),
+       (2, 1, 'CONGRATULATION'),
+       (3, 2, 'LOVE'),
+       (3, 3, 'LOVE'),
+       (3, 1, 'ROCKET'),
+       (5, 2, 'LOVE'),
+       (5, 4, 'CLAP'),
+       (5, 1, 'LOVE');
+
+INSERT INTO comment (bookmark_id, writer_id, contents, created_time, updated_time)
+VALUES (1, 1, 'content', '2000-01-01 00:00:00', '2000-01-01 00:00:00'),
+       (2, 2, 'content', '2000-01-02 00:00:00', '2000-01-02 00:00:00'),
+       (3, 1, 'content', '2000-01-03 00:00:00', '2000-01-03 00:00:00'),
+       (3, 2, 'content', '2000-01-04 00:00:00', '2000-01-04 00:00:00'),
+       (3, 3, 'content', '2000-01-05 00:00:00', '2000-01-05 00:00:00'),
+       (3, 1, 'content', '2000-01-06 00:00:00', '2000-01-06 00:00:00'),
+       (4, 1, 'content', '2000-01-07 00:00:00', '2000-01-07 00:00:00'),
+       (4, 1, 'content', '2000-01-08 00:00:00', '2000-01-08 00:00:00'),
+       (5, 2, 'content', '2000-01-09 00:00:00', '2000-01-09 00:00:00'),
+       (5, 3, 'content', '2000-01-10 00:00:00', '2000-01-10 00:00:00'),
+       (5, 1, 'content', '2000-01-11 00:00:00', '2000-01-11 00:00:00'),
+       (5, 4, 'content', '2000-01-12 00:00:00', '2000-01-12 00:00:00'),
+       (5, 1, 'content', '2000-01-13 00:00:00', '2000-01-13 00:00:00');
+
+INSERT INTO comment_reaction (comment_id, reactor_id, reaction)
+VALUES (1, 1, 'CLAP'),
+       (4, 2, 'LIKE'),
+       (4, 3, 'CONGRATULATION'),
+       (4, 2, 'LOVE'),
+       (4, 1, 'LOVE'),
+       (4, 3, 'LOVE'),
+       (6, 1, 'ROCKET'),
+       (6, 4, 'LIKE'),
+       (6, 2, 'LOVE'),
+       (7, 3, 'LOVE'),
+       (7, 2, 'CLAP'),
+       (7, 1, 'LOVE'),
+       (7, 4, 'ROCKET'),
+       (7, 2, 'LIKE'),
+       (8, 2, 'CLAP'),
+       (8, 1, 'CLAP'),
+       (11, 4, 'CONGRATULATION'),
+       (11, 3, 'LOVE'),
+       (11, 1, 'LIKE'),
+       (13, 3, 'ROCKET'),
+       (13, 1, 'LIKE'),
+       (13, 2, 'LIKE'),
+       (13, 4, 'CONGRATULATION'),
+       (13, 2, 'LOVE');


### PR DESCRIPTION
### 구현한 기능이 어떤 건가요?

- Bookmark와 Comment를 Slice해서 가져옵니다.

### 구현 방식, 기술을 택한 이유가 있다면 설명해 주세요

- 기존의 코드에서는 Bookmark, Comment, Reaction 개수만큼 api 요청이 갑니다. 첫 화면을 보여주기 위해서 한번에 정보를 넘겨줍니다.
- Slice를 적용해서 한번에 모든 정보를 보여주지 않습니다.

- Bookmark를 슬라이스를 할 때 JPA를 사용했기에, Bookmark Wirter과 Bookmark Reaction을 초기화하는 쿼리가 각각 나갑니다.
- Bookmark를 가져올 때 쿼리가 3번 나갑니다.
  - Bookmark 정보를 가져오는 쿼리(ORDER BY 와 LIMIT로 제한하기에 Reaction과 따로 보냄)
  - Bookmark Reaction의 정보를 가져오는 쿼리
  - Bookmark Reaction Reactor의 정보를 가져오는 쿼리

- Comment를 슬라이스 할떄는 `ROW_NUM()` 프로시저를 사용했기에 JdbcTemplate를 사용했습니다.
 - 또한 엔티티를 가져온 다음에 DTO로 변환하는게 아니라 `ResultSet`에서 바로 DTO로 변환합니다.
 - Comment를 가져올 때 2번의 쿼리가 나갑니다.
   - Comment 정보를 가져오는 쿼리
   - Comment Reaction 정보를 가져오는 쿼리

### 리뷰어에게 한마디 부탁드려요.

<!-- 어느 부분을 중점적으로 리뷰어가 보면 좋을 지 알려주세요. --->
